### PR TITLE
history\diplomacy output fix

### DIFF
--- a/EU4toV2/Source/V2World/V2Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/V2Diplomacy.cpp
@@ -33,9 +33,9 @@ std::ostream& operator<<(std::ostream& output, V2Agreement theAgreement)
 {
 	output << theAgreement.type << "=\n";
 	output << "{\n";
-	output << "\tfirst=\"" << theAgreement.country1 << "\"" << "\n";
-	output << "\tsecond=\"" << theAgreement.country2 << "\"" << "\n";
-	output << "\tstart_date=\"" << theAgreement.start_date << "\"" << "\n";
+	output << "\tfirst=\"" << theAgreement.country1 << "\"\n";
+	output << "\tsecond=\"" << theAgreement.country2 << "\"\n";
+	output << "\tstart_date=\"" << theAgreement.start_date << "\"\n";
 	output << "\tend_date=\"1936.1.1\"\n";
 	output << "}\n";
 	output << "\n";

--- a/EU4toV2/Source/V2World/V2Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/V2Diplomacy.cpp
@@ -33,9 +33,9 @@ std::ostream& operator<<(std::ostream& output, V2Agreement theAgreement)
 {
 	output << theAgreement.type << "=\n";
 	output << "{\n";
-	output << "\tfirst=\"" << theAgreement.country1 << "\n";
-	output << "\tsecond=\"" << theAgreement.country2 << "\n";
-	output << "\tstart_date=\"" << theAgreement.start_date << "\n";
+	output << "\tfirst=\"" << theAgreement.country1 << "\"" << "\n";
+	output << "\tsecond=\"" << theAgreement.country2 << "\"" << "\n";
+	output << "\tstart_date=\"" << theAgreement.start_date << "\"" << "\n";
 	output << "\tend_date=\"1936.1.1\"\n";
 	output << "}\n";
 	output << "\n";


### PR DESCRIPTION
Good news!

- I finally got some version of boost to work with VS
- I'm capable of editing the source beyong adding "Hello World!" to log ;)

Before my change the agreements looked like this (and obviously were broken in Vicky):

> guarantee=
> {
> 	first="BYZ
> 	second="GEO
> 	start_date="1812.7.8
> 	end_date="1936.1.1"
> }

Now the quote signs after tags and start date exist.