### PR TITLE
Province controllership is now converted 🎆

### DIFF
--- a/EU4toV2/EU4ToV2.vcxproj
+++ b/EU4toV2/EU4ToV2.vcxproj
@@ -119,7 +119,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\common_items;H:\boost_1_64_0;D:\Libraries\boost_1_55_0_lib;$(BOOST_INCLUDE);$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common_items;D:\boost_1_64_0;$(BOOST_INCLUDE);$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -128,7 +128,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>H:\boost_1_64_0\stage\lib;D:\Libraries\boost_1_55_0_lib\lib32-msvc-12.0;$(BOOST_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>D:\boost_1_64_0\lib32-msvc-12.0;$(BOOST_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command>Copy_Files.bat</Command>

--- a/EU4toV2/EU4ToV2.vcxproj
+++ b/EU4toV2/EU4ToV2.vcxproj
@@ -119,7 +119,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\common_items;D:\boost_1_64_0;$(BOOST_INCLUDE);$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common_items;H:\boost_1_64_0;D:\boost_1_64_0;D:\Libraries\boost_1_55_0_lib;$(BOOST_INCLUDE);$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -128,7 +128,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>D:\boost_1_64_0\lib32-msvc-12.0;$(BOOST_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>H:\boost_1_64_0\stage\lib;D:\boost_1_64_0\lib32-msvc-12.0;D:\Libraries\boost_1_55_0_lib\lib32-msvc-12.0;$(BOOST_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command>Copy_Files.bat</Command>

--- a/EU4toV2/Source/EU4World/Provinces/EU4Province.cpp
+++ b/EU4toV2/Source/EU4World/Provinces/EU4Province.cpp
@@ -59,6 +59,10 @@ EU4::Province::Province(const std::string& numString, std::istream& theStream)
 		commonItems::singleString ownerStringString(theStream);
 		ownerString = ownerStringString.getString();
 	});
+	registerKeyword(std::regex("controller"), [this](const std::string& unused, std::istream& theStream) {
+		commonItems::singleString controllerStringString(theStream);
+		controllerString = controllerStringString.getString();
+	});
 	registerKeyword(std::regex("cores"), [this](const std::string& unused, std::istream& theStream) {
 		commonItems::stringList coresStrings(theStream);
 		for (auto coreString : coresStrings.getStrings())

--- a/EU4toV2/Source/EU4World/Provinces/EU4Province.h
+++ b/EU4toV2/Source/EU4World/Provinces/EU4Province.h
@@ -59,6 +59,7 @@ class Province: commonItems::parser
 		int getNum() const { return num; }
 		std::string getName() const { return name; }
 		std::string getOwnerString() const { return ownerString; }
+		std::string getControllerString() const { return controllerString; }
 		std::set<std::string> getCores() const { return cores; }
 		bool inHre() const { return inHRE; }
 		bool isColony() const { return colony; }
@@ -87,6 +88,7 @@ class Province: commonItems::parser
 		int num = 0;
 		std::string	name;
 		std::string ownerString;
+		std::string controllerString;
 		std::set<std::string> cores;
 
 		bool inHRE = false;

--- a/EU4toV2/Source/V2World/V2Country.cpp
+++ b/EU4toV2/Source/V2World/V2Country.cpp
@@ -1315,6 +1315,7 @@ void V2Country::absorbVassal(V2Country* vassal)
 	for (auto provItr = vassalProvinces.begin(); provItr != vassalProvinces.end(); provItr++)
 	{
 		provItr->second->setOwner(tag);
+		provItr->second->setController(tag);
 		provItr->second->addCore(tag);
 	}
 	vassal->provinces.clear();

--- a/EU4toV2/Source/V2World/V2Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/V2Diplomacy.cpp
@@ -33,9 +33,9 @@ std::ostream& operator<<(std::ostream& output, V2Agreement theAgreement)
 {
 	output << theAgreement.type << "=\n";
 	output << "{\n";
-	output << "\tfirst=\"" << theAgreement.country1 << "\"" << "\n";
-	output << "\tsecond=\"" << theAgreement.country2 << "\"" << "\n";
-	output << "\tstart_date=\"" << theAgreement.start_date << "\"" << "\n";
+	output << "\tfirst=\"" << theAgreement.country1 << "\"\n";
+	output << "\tsecond=\"" << theAgreement.country2 << "\"\n";
+	output << "\tstart_date=\"" << theAgreement.start_date << "\"\n";
 	output << "\tend_date=\"1936.1.1\"\n";
 	output << "}\n";
 	output << "\n";

--- a/EU4toV2/Source/V2World/V2Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/V2Diplomacy.cpp
@@ -33,9 +33,9 @@ std::ostream& operator<<(std::ostream& output, V2Agreement theAgreement)
 {
 	output << theAgreement.type << "=\n";
 	output << "{\n";
-	output << "\tfirst=\"" << theAgreement.country1 << "\n";
-	output << "\tsecond=\"" << theAgreement.country2 << "\n";
-	output << "\tstart_date=\"" << theAgreement.start_date << "\n";
+	output << "\tfirst=\"" << theAgreement.country1 << "\"" << "\n";
+	output << "\tsecond=\"" << theAgreement.country2 << "\"" << "\n";
+	output << "\tstart_date=\"" << theAgreement.start_date << "\"" << "\n";
 	output << "\tend_date=\"1936.1.1\"\n";
 	output << "}\n";
 	output << "\n";

--- a/EU4toV2/Source/V2World/V2Province.cpp
+++ b/EU4toV2/Source/V2World/V2Province.cpp
@@ -50,7 +50,7 @@ V2Province::V2Province(string _filename)
 	num = 0;
 	name = "";
 	owner = "";
-	//controler			= "";
+	controller = "";
 	cores.clear();
 	inHRE = false;
 	colonyLevel = 0;
@@ -114,7 +114,7 @@ V2Province::V2Province(string _filename)
 		}
 		else if ((*itr)->getKey() == "controller")
 		{
-			//controller = (*itr)->getLeaf().c_str();
+			controller = (*itr)->getLeaf().c_str();
 		}
 		else if ((*itr)->getKey() == "add_core")
 		{
@@ -188,7 +188,7 @@ void V2Province::output() const
 	if (owner != "")
 	{
 		output << "owner=" << owner << "\n";
-		output << "controller=" << owner << "\n";
+		output << "controller=" << controller << "\n";
 	}
 	for (auto core: cores)
 	{

--- a/EU4toV2/Source/V2World/V2Province.cpp
+++ b/EU4toV2/Source/V2World/V2Province.cpp
@@ -50,7 +50,7 @@ V2Province::V2Province(string _filename)
 	num = 0;
 	name = "";
 	owner = "";
-	controller = "";
+	//controller = ""; // disabled because string defaults to "" anyway
 	cores.clear();
 	inHRE = false;
 	colonyLevel = 0;

--- a/EU4toV2/Source/V2World/V2Province.h
+++ b/EU4toV2/Source/V2World/V2Province.h
@@ -89,6 +89,7 @@ class V2Province
 		void				setCoastal(bool _coastal)					{ coastal = _coastal; }
 		void				setName(string _name)						{ name = _name; }
 		void				setOwner(string _owner)						{ owner = _owner; }
+		void				setController(string _controller)						{ controller = _controller; }
 		void				setLandConnection(bool _connection)		{ landConnection = _connection; }
 		void				setSameContinent(bool _same)				{ sameContinent = _same; }
 		void				setFortLevel(int level)						{ fortLevel = level; }
@@ -104,6 +105,7 @@ class V2Province
 		bool						isColonial()			const { return colonial != 0; }
 		string					getRgoType()			const { return rgoType; }
 		string					getOwner()				const { return owner; }
+		string					getController()				const { return controller; }
 		int						getNum()					const { return num; }
 		string					getName()				const { return name; }
 		bool						isCoastal()				const { return coastal; }

--- a/EU4toV2/Source/V2World/V2Province.h
+++ b/EU4toV2/Source/V2World/V2Province.h
@@ -145,6 +145,7 @@ class V2Province
 		int							num;
 		string						name;
 		string						owner;
+		string						controller;
 		vector<string>				cores;
 		bool							inHRE;
 		int							colonyLevel;

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -744,12 +744,12 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 			{
 				provinceBins[ownerTag] = MTo1ProvinceComp();
 			}
-			if (provinceBins.find(controllerTag) == provinceBins.end()) // TODO: ask Idhrendur if this is needed
+			if (provinceBins.find(controllerTag) == provinceBins.end())
 			{
 				provinceBins[controllerTag] = MTo1ProvinceComp();
 			}
 			provinceBins[ownerTag].provinces.push_back(&province);
-			provinceBins[controllerTag].provinces.push_back(&province); // TODO: ask Idhrendur if this is needed
+			provinceBins[controllerTag].provinces.push_back(&province);
 			newProvinceTotalBaseTax += province.getBaseTax();
 			// I am the new owner if there is no current owner, or I have more provinces than the current owner,
 			// or I have the same number of provinces, but more population, than the current owner

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -727,10 +727,11 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 			continue;
 		}
 
-		Vic2Province.second->clearCores();
+		Vic2Province.second->clearCores(); //// TODO: LOOK HERE if you work on controller!
 
 		const EU4::Province* oldProvince = nullptr;
 		std::string oldOwnerTag;
+		std::string oldControllerTag;
 		// determine ownership by province count, or total population (if province count is tied)
 		map<string, MTo1ProvinceComp> provinceBins;
 		double newProvinceTotalBaseTax = 0;
@@ -738,6 +739,7 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 		{
 			const EU4::Province& province = sourceWorld.getProvince(EU4ProvinceNumber);
 			auto ownerTag = province.getOwnerString();
+			auto controllerTag = province.getControllerString();
 			if (provinceBins.find(ownerTag) == provinceBins.end())
 			{
 				provinceBins[ownerTag] = MTo1ProvinceComp();
@@ -753,12 +755,14 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 				)
 			{
 				oldOwnerTag = ownerTag;
+				oldControllerTag = controllerTag;
 				oldProvince = &province;
 			}
 		}
 		if (oldOwnerTag == "")
 		{
 			Vic2Province.second->setOwner("");
+			Vic2Province.second->setController("");
 			continue;
 		}
 
@@ -770,6 +774,7 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 		else
 		{
 			Vic2Province.second->setOwner(V2Tag);
+			Vic2Province.second->setController(V2Tag);
 			map<string, V2Country*>::iterator ownerItr = countries.find(V2Tag);
 			if (ownerItr != countries.end())
 			{

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -727,7 +727,7 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 			continue;
 		}
 
-		Vic2Province.second->clearCores(); //// TODO: LOOK HERE if you work on controller!
+		Vic2Province.second->clearCores();
 
 		const EU4::Province* oldProvince = nullptr;
 		std::string oldOwnerTag;
@@ -744,7 +744,12 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 			{
 				provinceBins[ownerTag] = MTo1ProvinceComp();
 			}
+			if (provinceBins.find(controllerTag) == provinceBins.end()) // TODO: ask Idhrendur if this is needed
+			{
+				provinceBins[controllerTag] = MTo1ProvinceComp();
+			}
 			provinceBins[ownerTag].provinces.push_back(&province);
+			provinceBins[controllerTag].provinces.push_back(&province); // TODO: ask Idhrendur if this is needed
 			newProvinceTotalBaseTax += province.getBaseTax();
 			// I am the new owner if there is no current owner, or I have more provinces than the current owner,
 			// or I have the same number of provinces, but more population, than the current owner
@@ -766,6 +771,7 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 			continue;
 		}
 
+		const std::string& V2ControllerTag = mappers::CountryMappings::getVic2Tag(oldControllerTag);
 		const std::string& V2Tag = mappers::CountryMappings::getVic2Tag(oldOwnerTag);
 		if (V2Tag.empty())
 		{
@@ -774,12 +780,13 @@ void V2World::convertProvinces(const EU4::world& sourceWorld)
 		else
 		{
 			Vic2Province.second->setOwner(V2Tag);
-			Vic2Province.second->setController(V2Tag);
+			Vic2Province.second->setController(V2ControllerTag);
 			map<string, V2Country*>::iterator ownerItr = countries.find(V2Tag);
 			if (ownerItr != countries.end())
 			{
 				ownerItr->second->addProvince(Vic2Province.second);
 			}
+			map<string, V2Country*>::iterator controllerItr = countries.find(V2Tag);
 			Vic2Province.second->convertFromOldProvince(sourceWorld.getAllReligions(), oldProvince, sourceWorld.getCountries());
 
 			for (map<string, MTo1ProvinceComp>::iterator mitr = provinceBins.begin(); mitr != provinceBins.end(); ++mitr)


### PR DESCRIPTION
- Added controllership conversion. Currently this only makes a difference in the country selection screen, because without wars and rebels converted, the game immediately removes controllership on campaign start.
- Added my boost dir to vcxproj

There are two edited parts which I'm particularly unsure about, marked them with a "TODO: ask Idhrendur" comment.