### PR TITLE
Clean parse states

### DIFF
--- a/EU4toV2/CMakeLists.txt
+++ b/EU4toV2/CMakeLists.txt
@@ -39,6 +39,7 @@ set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/NewParserToOldParserConver
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParadoxParser8859_15.cpp")
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParadoxParserUTF8.cpp")
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParserHelpers.cpp")
+set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/StringUtils.cpp")
 
 set(Boost_USE_STATIC_LIBS       OFF)
 set(Boost_USE_MULTITHREADED     OFF)

--- a/EU4toV2/EU4ToV2.vcxproj
+++ b/EU4toV2/EU4ToV2.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="..\common_items\ParadoxParser8859_15.cpp" />
     <ClCompile Include="..\common_items\ParadoxParserUTF8.cpp" />
     <ClCompile Include="..\common_items\ParserHelpers.cpp" />
+    <ClCompile Include="..\common_items\StringUtils.cpp" />
     <ClCompile Include="..\common_items\WinUtils.cpp" />
     <ClCompile Include="Source\Configuration.cpp" />
     <ClCompile Include="Source\EU4toV2Converter.cpp" />
@@ -277,6 +278,7 @@
     <ClInclude Include="..\common_items\ParadoxParser8859_15.h" />
     <ClInclude Include="..\common_items\ParadoxParserUTF8.h" />
     <ClInclude Include="..\common_items\ParserHelpers.h" />
+    <ClInclude Include="..\common_items\StringUtils.h" />
     <ClInclude Include="Source\Configuration.h" />
     <ClInclude Include="Source\CustomFlagMapper.h" />
     <ClInclude Include="Source\EU4ToVic2Converter.h" />

--- a/EU4toV2/Source/EU4World/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/EU4Country.cpp
@@ -601,7 +601,7 @@ void EU4::Country::addCore(EU4::Province* core)
 	cores.push_back(core);
 }
 
-void EU4::Country::addState(const std::string area, double prosperity)
+void EU4::Country::addState(const std::string& area, double prosperity)
 {
 	states[area] = prosperity;
 	for (EU4::Province* p : provinces)

--- a/EU4toV2/Source/EU4World/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/EU4Country.cpp
@@ -601,6 +601,17 @@ void EU4::Country::addCore(EU4::Province* core)
 	cores.push_back(core);
 }
 
+void EU4::Country::addState(const std::string area, double prosperity)
+{
+	states[area] = prosperity;
+	for (EU4::Province* p : provinces)
+	{
+		if (p->getArea() == area)
+		{
+			p->makeState(prosperity);
+		}
+	}
+}
 
 bool EU4::Country::hasModifier(string modifier) const
 {

--- a/EU4toV2/Source/EU4World/EU4Country.h
+++ b/EU4toV2/Source/EU4World/EU4Country.h
@@ -74,7 +74,7 @@ namespace EU4
 
 			void addProvince(Province*);
 			void addCore(Province*);
-	                void addState(const std::string area, double prosperity);
+	                void addState(const std::string area&, double prosperity);
 	                void						setInHRE(bool _inHRE)								{ inHRE = _inHRE; }
 			void						setEmperor(bool _emperor)							{ holyRomanEmperor = _emperor; }
 			void						setCelestialEmperor(bool _celestialEmperor)			{ celestialEmperor = _celestialEmperor; }

--- a/EU4toV2/Source/EU4World/EU4Country.h
+++ b/EU4toV2/Source/EU4World/EU4Country.h
@@ -74,7 +74,7 @@ namespace EU4
 
 			void addProvince(Province*);
 			void addCore(Province*);
-	                void addState(const std::string area&, double prosperity);
+	                void addState(const std::string& area, double prosperity);
 	                void						setInHRE(bool _inHRE)								{ inHRE = _inHRE; }
 			void						setEmperor(bool _emperor)							{ holyRomanEmperor = _emperor; }
 			void						setCelestialEmperor(bool _celestialEmperor)			{ celestialEmperor = _celestialEmperor; }

--- a/EU4toV2/Source/EU4World/EU4Country.h
+++ b/EU4toV2/Source/EU4World/EU4Country.h
@@ -74,7 +74,8 @@ namespace EU4
 
 			void addProvince(Province*);
 			void addCore(Province*);
-			void						setInHRE(bool _inHRE)								{ inHRE = _inHRE; }
+	                void addState(const std::string area, double prosperity);
+	                void						setInHRE(bool _inHRE)								{ inHRE = _inHRE; }
 			void						setEmperor(bool _emperor)							{ holyRomanEmperor = _emperor; }
 			void						setCelestialEmperor(bool _celestialEmperor)			{ celestialEmperor = _celestialEmperor; }
 			bool						hasModifier(string) const;
@@ -195,6 +196,7 @@ namespace EU4
 
 			map<string, string> namesByLanguage;		// the names of this country in different localisations
 			map<string, string> adjectivesByLanguage;	// the adjectives for this country in different localisations
+	                map<string, double> states; // Areas which have been made states by this country.
 	};
 }
 

--- a/EU4toV2/Source/EU4World/Provinces/EU4Province.cpp
+++ b/EU4toV2/Source/EU4World/Provinces/EU4Province.cpp
@@ -186,6 +186,11 @@ double EU4::Province::getCulturePercent(const std::string& culture) const
 	return culturePercent;
 }
 
+void EU4::Province::makeState(double p)
+{
+	stated = true;
+	prosperity = p;
+}
 
 void EU4::Province::determineProvinceWeight(const Buildings& buildingTypes, const Modifiers& modifierTypes)
 {

--- a/EU4toV2/Source/EU4World/Provinces/EU4Province.h
+++ b/EU4toV2/Source/EU4World/Provinces/EU4Province.h
@@ -67,6 +67,7 @@ class Province: commonItems::parser
 		bool hasGreatProject(const std::string& greatProject) const;
 		double getCulturePercent(const std::string& culture) const;
 
+		std::string getArea() const { return areaName; }
 		int getNum() const { return num; }
 		std::string getName() const { return name; }
 		std::string getOwnerString() const { return ownerString; }
@@ -74,7 +75,8 @@ class Province: commonItems::parser
 		std::set<std::string> getCores() const { return cores; }
 		bool inHre() const { return inHRE; }
 		bool isColony() const { return colony; }
-		bool wasColonised() const { return hadOriginalColoniser || provinceHistory->wasColonized(); }
+	        bool isState() const { return stated; }
+	        bool wasColonised() const { return hadOriginalColoniser || provinceHistory->wasColonized(); }
 		bool hasModifier(const std::string& modifierName) const { return modifiers.count(modifierName) > 0; }
 		std::vector<EU4::PopRatio> getPopRatios() const { return provinceHistory->getPopRatios(); }
 		std::optional<date> getFirstOwnedDate() const { return provinceHistory->getFirstOwnedDate(); }
@@ -89,8 +91,12 @@ class Province: commonItems::parser
 		double getTotalDevModifier() const { return devModifier; }
 		ProvinceStats getProvinceStats() const { return provinceStats; }
 		std::string getTradeGoods() const { return tradeGoods; }
+	        double getProsperity() const { return prosperity; }
 
-	private:
+	        void setArea(const std::string& a) { areaName = a; }
+	        void makeState(double p);
+
+	      private:
 		void determineProvinceWeight(const Buildings& buildingTypes, const Modifiers& modifierTypes);
 		BuildingWeightEffects getProvBuildingWeight(const Buildings& buildingTypes, const Modifiers& modifierTypes) const;
 		double getTradeGoodPrice() const;
@@ -116,6 +122,7 @@ class Province: commonItems::parser
 		double manpower = 0.0;
 		double totalWeight = 0.0;
 		std::string tradeGoods;
+		std::string areaName;
 		double taxIncome = 0;
 		double productionIncome = 0;
 		double manpowerWeight = 0;
@@ -123,6 +130,8 @@ class Province: commonItems::parser
 		double devModifier = 0;
 		int centerOfTradeLevel = 0;
 		ProvinceStats provinceStats;
+	        double prosperity = 0;
+	        bool stated = false;
 };
 
 }

--- a/EU4toV2/Source/EU4World/World.h
+++ b/EU4toV2/Source/EU4World/World.h
@@ -87,6 +87,7 @@ class world: private commonItems::parser
 		void loadRevolutionTarget();
 		void addProvinceInfoToCountries();
 		void loadDiplomacy(const shared_ptr<Object> EU4SaveObj);
+		void loadMapAreaData(const shared_ptr<Object> mapAreaObject);
 
 		void loadRegions();
 		void loadEU4RegionsNewVersion();
@@ -108,8 +109,9 @@ class world: private commonItems::parser
 		void removeLandlessNations();
 
 		void setEmpires();
+	        void assignProvincesToAreas(const std::map<std::string, std::set<int>>& theAreas);
 
-		std::shared_ptr<EU4::Country> getCountry(string tag) const;
+	        std::shared_ptr<EU4::Country> getCountry(string tag) const;
 
 		string holyRomanEmperor;
 		string celestialEmperor;


### PR DESCRIPTION
Add parsing of the map_area_data object in the EU4 savegame, which contains country-level state data; this enables provinces to expose whether they are in a state, and what their prosperity is.

Tested on a savegame from my latest megacampaign.