### PR TITLE
Fix to broken territorial handling (colony vs territorial province)

### DIFF
--- a/EU4toV2/Source/EU4World/Provinces/EU4Province.cpp
+++ b/EU4toV2/Source/EU4World/Provinces/EU4Province.cpp
@@ -95,6 +95,13 @@ EU4::Province::Province(
 			inHRE = true;
 		}
 	});
+	registerKeyword(std::regex("is_city"), [this](const std::string& unused, std::istream& theStream) {
+		commonItems::singleString cityString(theStream);
+		if (cityString.getString() == "yes")
+		{
+			city = true;
+		}
+	});
 	registerKeyword(std::regex("colonysize"), [this](const std::string & unused, std::istream & theStream) {
 		commonItems::ignoreItem(unused, theStream);
 		colony = true;

--- a/EU4toV2/Source/EU4World/Provinces/EU4Province.h
+++ b/EU4toV2/Source/EU4World/Provinces/EU4Province.h
@@ -76,6 +76,7 @@ class Province: commonItems::parser
 		bool inHre() const { return inHRE; }
 		bool isTerritorialCore() const { return territorialCore; }
 		bool isColony() const { return colony; }
+		bool isCity() const { return city; }
 		bool isState() const { return stated; }
 		bool wasColonised() const { return hadOriginalColoniser || provinceHistory->wasColonized(); }
 		bool hasModifier(const std::string& modifierName) const { return modifiers.count(modifierName) > 0; }
@@ -114,6 +115,7 @@ class Province: commonItems::parser
 		bool colony = false;
 		bool hadOriginalColoniser = false;
 		bool territorialCore = false;
+		bool city = false;
 
 		std::unique_ptr<EU4::ProvinceHistory> provinceHistory;
 		std::unique_ptr<EU4::ProvinceBuildings> buildings;

--- a/EU4toV2/Source/V2World/V2Province.cpp
+++ b/EU4toV2/Source/V2World/V2Province.cpp
@@ -335,7 +335,7 @@ void V2Province::convertFromOldProvince(
 ) {
 	srcProvince = oldProvince;
 	inHRE = oldProvince->inHre();
-	if (oldProvince->isColony())
+	if (!oldProvince->isCity())
 	{
 		colonial = 1;
 		territorialCore = true;


### PR DESCRIPTION
I messed up with isColony assuming it returned isColony instead of wasColony. This will fix broken ex-colonies.