### PR TITLE
Fix for #54

### DIFF
--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -98,7 +98,8 @@ V2World::V2World(const EU4::world& sourceWorld, const mappers::IdeaEffectMapper&
 	addUnions();
 	convertArmies(sourceWorld);
 
-	output();
+	auto potentialGPs = countCivilizedNations();
+	output(potentialGPs);
 }
 
 
@@ -1812,7 +1813,7 @@ void V2World::convertArmies(const EU4::world& sourceWorld)
 	}
 }
 
-void V2World::output()
+void V2World::output(unsigned int potentialGPs) const
 {
 	LOG(LogLevel::Info) << "Outputting mod";
 	Utils::copyFolder("blankMod/output", "output/output");
@@ -1837,7 +1838,6 @@ void V2World::output()
 
 	// Update bookmark starting dates
 
-	auto potentialGPs = countCivilizedNations();
 	string startDate = "<STARTDATE>";
 	string numGPs = "GREAT_NATIONS_COUNT = 8";
 

--- a/EU4toV2/Source/V2World/V2World.h
+++ b/EU4toV2/Source/V2World/V2World.h
@@ -93,8 +93,7 @@ class V2World
 		void convertNationalValues(const mappers::IdeaEffectMapper& ideaEffectMapper);
 		void convertPrestige();
 		void addAllPotentialCountries();
-		void checkForCivilizedNations();
-		void editDefines(int numCivilisedNations);
+		unsigned int countCivilizedNations();
 
 		void convertProvinces(const EU4::world& sourceWorld);
 		std::vector<V2Demographic> determineDemographics(
@@ -117,7 +116,7 @@ class V2World
 		void addUnions();
 		void convertArmies(const EU4::world& sourceWorld);
 
-		void output() const;
+		void output();
 		void createModFile() const;
 		void outputPops() const;
 

--- a/EU4toV2/Source/V2World/V2World.h
+++ b/EU4toV2/Source/V2World/V2World.h
@@ -116,7 +116,7 @@ class V2World
 		void addUnions();
 		void convertArmies(const EU4::world& sourceWorld);
 
-		void output();
+		void output(unsigned int potentialGPs) const;
 		void createModFile() const;
 		void outputPops() const;
 


### PR DESCRIPTION
- code will now correctly replace the amount of great nations.

Tested a roman empire almost-wc with default 8 nations, game crashed on adapting history after selecting a country to play. After this fix with just 1 civilized nation it loads well:

![rome](https://user-images.githubusercontent.com/2392697/71479269-e4f4b500-27f3-11ea-8b89-5bb44a86bbb3.png)
