### PR TITLE
Fix for PSNS Flag ordering

### DIFF
--- a/EU4toV2/Source/EU4World/Country/EU4CustomColors.cpp
+++ b/EU4toV2/Source/EU4World/Country/EU4CustomColors.cpp
@@ -9,7 +9,15 @@ EU4::CustomColors::CustomColors(std::istream& theStream)
 	registerKeyword(std::regex("flag"), [this](const std::string& unused, std::istream& theStream)
 		{
 			commonItems::singleInt flagInt(theStream);
-			customColors.flag = flagInt.getInt() + 1;
+			// Why, paradox, why?
+			if (flagInt.getInt() < 0) 
+			{
+				customColors.flag = 1;
+			}
+			else
+			{
+				customColors.flag = flagInt.getInt() + 1;
+			}
 		}
 	);
 	registerKeyword(std::regex("color"), [this](const std::string& unused, std::istream& theStream)

--- a/EU4toV2/Source/EU4World/Country/EU4CustomColors.h
+++ b/EU4toV2/Source/EU4World/Country/EU4CustomColors.h
@@ -9,7 +9,7 @@ namespace EU4
 {
 	struct CustomColorsBlock
 	{
-		int flag = -1;
+		int flag = 0;
 		int color = 0;
 		int symbolIndex = 0;
 		commonItems::Color flagColors = commonItems::Color(0, 0, 0);

--- a/EU4toV2/Source/EU4World/Country/EU4NationalSymbol.cpp
+++ b/EU4toV2/Source/EU4World/Country/EU4NationalSymbol.cpp
@@ -1,24 +1,3 @@
-/*Copyright(c) 2019 The Paradox Game Converters Project
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files(the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE. */
-
-
 #include "EU4NationalSymbol.h"
 #include "Log.h"
 #include "NewParserToOldParserConverters.h"

--- a/EU4toV2/Source/EU4World/Country/EU4NationalSymbol.h
+++ b/EU4toV2/Source/EU4World/Country/EU4NationalSymbol.h
@@ -1,24 +1,3 @@
-/*Copyright(c) 2019 The Paradox Game Converters Project
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files(the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE. */
-
-
 #ifndef EU4_NATIONALSYMBOL_H_
 #define EU4_NATIONALSYMBOL_H_
 

--- a/EU4toV2/Source/V2World/V2Flags.cpp
+++ b/EU4toV2/Source/V2World/V2Flags.cpp
@@ -392,10 +392,10 @@ void V2Flags::createCustomFlags() const
 
 		for (int i = 0; i<5; i++)
 		{
-			if (baseFlag < 0)
+			if (baseFlag == 0)
 				baseFlagStr = "tricolor";
 
-			if ((baseFlag < 0) && i != 0 && i != 4)
+			if ((baseFlag == 0) && i != 0 && i != 4)
 				continue;
 
 			const string& suffix = flagFileSuffixes[i];


### PR DESCRIPTION
Paradox Special Naming System:
Blank flags and symbols are -1 in save.
Regular flags start at 2
Regular symbols start at 1
Why.