### PR TITLE
Eu4army fix

### DIFF
--- a/EU4toV2/Source/EU4World/Army/EU4Army.h
+++ b/EU4toV2/Source/EU4World/Army/EU4Army.h
@@ -1,6 +1,7 @@
 #ifndef EU4_ARMY_H
 #define EU4_ARMY_H
 
+#include <unordered_map>
 #include <vector>
 #include <set>
 #include "EU4Regiment.h"
@@ -9,7 +10,7 @@
 
 namespace EU4
 {
-	class EU4Army : public  commonItems::parser
+	class EU4Army : public commonItems::parser
 	{
 	public:
 		EU4Army() = default;
@@ -28,13 +29,17 @@ namespace EU4
 		void blockHomeProvince(const int homeId);
 
 	private:
+                void initialiseHomeProvinces();
 		std::string name;
 		int location = -1;
 		int atSea = 0; // obsolete since 1.20
 		int armyId = 0;
 		int leaderId = 0;
 		std::vector<EU4Regiment> regimentList;
-		std::set<int> blocked_homes; // invalid homes for this army
-	};
+	        // Unblocked home provinces; note that a province can be listed
+	        // multiple times.
+	        std::unordered_map<REGIMENTCATEGORY, std::vector<int>>
+	            home_provinces;
+        };
 }
-#endif // EU4_ARMY_H
+#endif // EU4_ARMY_H_

--- a/EU4toV2/Source/V2World/V2Army.h
+++ b/EU4toV2/Source/V2World/V2Army.h
@@ -55,7 +55,7 @@ class V2Army // also Navy
 		std::string getName() const { return name; };
 		void getRegimentCounts(int counts[static_cast<int>(EU4::REGIMENTCATEGORY::num_reg_categories)]) const;
 		double getArmyRemainder(EU4::REGIMENTCATEGORY category) const { return armyRemainders[static_cast<int>(category)]; };
-		EU4::EU4Army getSourceArmy() const { return sourceArmy; };
+		EU4::EU4Army& getSourceArmy() { return sourceArmy; };
 		bool getNavy() const { return isNavy; };
 
 		static V2Army* makeTestNavy(int location);


### PR DESCRIPTION
This PR does two things:

1. Fixes a bug by changing V2Army::getSourceArmy to return the EU4 object by reference, not copy. Without this, changes made to the source army, as for example by calling blockHomeProvince, do not persist; which causes an infinite loop in the case of unmatched provinces.
2. Optimises the home-province calculation by caching the provinces at army creation instead of re-iterating over the regiments every time.

Note that I have restored the old behaviour where a province is selected with a probability equal to the fraction of regiments that have that home province; the recent fix made all provinces equally probable by changing the local homeProvinces variable from a vector to a set. Let me know if that was deliberate, and I'll put it back.