### PR TITLE
Use religion, not culture, date in religion conversion events. Using …

### DIFF
--- a/EU4toV2/Source/EU4World/Provinces/ProvinceHistory.cpp
+++ b/EU4toV2/Source/EU4World/Provinces/ProvinceHistory.cpp
@@ -171,7 +171,7 @@ void EU4::ProvinceHistory::buildPopRatios()
 		}
 		else if (religionEventDate < cultureEventDate)
 		{
-			decayPopRatios(lastLoopDate, cultureEventDate, currentRatio);
+			decayPopRatios(lastLoopDate, religionEventDate, currentRatio);
 			popRatios.push_back(currentRatio);
 			for (auto& itr: popRatios)
 			{


### PR DESCRIPTION
Fixes a bug in which the culture date is used for religious conversion events, leading presumably to the wrong amount of conversion happening.