### PR TITLE
Fixed tech ranking

### DIFF
--- a/EU4toV2/Source/Helpers/TechValues.cpp
+++ b/EU4toV2/Source/Helpers/TechValues.cpp
@@ -2,42 +2,65 @@
 #include "../EU4World/Country/EU4Country.h"
 #include "../V2World/Country/Country.h"
 #include <algorithm>
+#include "Log.h"
 
 helpers::TechValues::TechValues(const std::map<std::string, std::shared_ptr<V2::Country>>& countries)
 {
-	auto numValidCountries = 0;
-	double armyTotal = 0;
-	double navyTotal = 0;
-	double commerceTotal = 0;
-	double cultureTotal = 0;
-	double industryTotal = 0;
-
+	std::vector<double> armyScores;
+	std::vector<double> navyScores;
+	std::vector<double> commerceScores;
+	std::vector<double> cultureScores;
+	std::vector<double> industryScores;
+	int totalCountries = 0;
+	
 	for (const auto& countryItr: countries)
 	{
 		const auto& country = countryItr.second;
 		if (!isValidCountryForTechConversion(*country)) continue;
 
-		armyMax = std::max(armyMax, getCountryArmyTech(*country->getSourceCountry()));
-		armyTotal += getCountryArmyTech(*country->getSourceCountry());
-		navyMax = std::max(navyMax, getCountryNavyTech(*country->getSourceCountry()));
-		navyTotal += getCountryNavyTech(*country->getSourceCountry());
-		commerceMax = std::max(commerceMax, getCountryCommerceTech(*country->getSourceCountry()));
-		commerceTotal += getCountryCommerceTech(*country->getSourceCountry());
-		cultureMax = std::max(cultureMax, getCountryCultureTech(*country->getSourceCountry()));
-		cultureTotal += getCountryCultureTech(*country->getSourceCountry());
-		industryMax = std::max(industryMax, getCountryIndustryTech(*country->getSourceCountry()));
-		industryTotal += getCountryIndustryTech(*country->getSourceCountry());
-		numValidCountries++;
+		auto armyScore = getCountryArmyTech(*country->getSourceCountry());
+		armyScores.emplace_back(armyScore);
+		armyMean += armyScore;
+
+		auto navyScore = getCountryNavyTech(*country->getSourceCountry());
+		navyScores.emplace_back(navyScore);
+		navyMean += navyScore;
+
+		auto commerceScore = getCountryCommerceTech(*country->getSourceCountry());
+		commerceScores.emplace_back(commerceScore);
+		commerceMean += commerceScore;
+
+		auto cultureScore = getCountryCultureTech(*country->getSourceCountry());
+		cultureScores.emplace_back(cultureScore);
+		cultureMean += cultureScore;
+
+		auto industryScore = getCountryIndustryTech(*country->getSourceCountry());
+		industryScores.emplace_back(industryScore);
+		industryMean += industryScore;
+		
+		++totalCountries;
 	}
 
-	if (numValidCountries > 0)
-	{
-		armyMean = armyTotal / numValidCountries;
-		navyMean = navyTotal / numValidCountries;
-		commerceMean = commerceTotal / numValidCountries;
-		cultureMean = cultureTotal / numValidCountries;
-		industryMean = industryTotal / numValidCountries;
-	}
+	if (!armyScores.empty()) armyMean /= totalCountries;
+	if (!navyScores.empty()) navyMean /= totalCountries;
+	if (!commerceScores.empty()) commerceMean /= totalCountries;
+	if (!cultureScores.empty()) cultureMean /= totalCountries;
+	if (!industryScores.empty()) industryMean /= totalCountries;
+
+	armyMean = dropOutliers(armyScores, armyMean);
+	navyMean = dropOutliers(navyScores, navyMean);
+	commerceMean = dropOutliers(commerceScores, commerceMean);
+	cultureMean = dropOutliers(cultureScores, cultureMean);
+	industryMean = dropOutliers(industryScores, industryMean);
+	
+	if (!armyScores.empty()) armyMax = armyScores.back();
+	if (!navyScores.empty()) navyMax = navyScores.back();
+	if (!commerceScores.empty()) commerceMax = commerceScores.back();
+	if (!cultureScores.empty()) cultureMax = cultureScores.back();
+	if (!industryScores.empty()) industryMax = industryScores.back();
+
+	Log(LogLevel::Debug) << "Industry median : " << industryMedian << "Industry mean : " << industryMean << "industry min : " << industryMin << " industry max: " << industryMax;
+
 }
 
 bool helpers::TechValues::isValidCountryForTechConversion(const V2::Country& country)
@@ -47,57 +70,78 @@ bool helpers::TechValues::isValidCountryForTechConversion(const V2::Country& cou
 
 double helpers::TechValues::getNormalizedArmyTech(const EU4::Country& country) const
 {
-	return getNormalizedScore(
-		getCountryArmyTech(country), armyMax, armyMean);
+	return getNormalizedScore(getCountryArmyTech(country), armyMax, armyMedian);
 }
 
 double helpers::TechValues::getNormalizedNavyTech(const EU4::Country& country) const
 {
-	return getNormalizedScore(getCountryNavyTech(country), navyMax, navyMean);
+	return getNormalizedScore(getCountryNavyTech(country), navyMax, navyMedian);
 }
 
 double helpers::TechValues::getNormalizedCommerceTech(const EU4::Country& country) const
 {
-	return getNormalizedScore(getCountryCommerceTech(country), commerceMax, commerceMean);
+	return getNormalizedScore(getCountryCommerceTech(country), commerceMax, commerceMedian);
 }
 
 double helpers::TechValues::getNormalizedCultureTech(const EU4::Country& country) const
 {
-	return getNormalizedScore(getCountryCultureTech(country), cultureMax, cultureMean);
+	return getNormalizedScore(getCountryCultureTech(country), cultureMax, cultureMedian);
 }
 
 double helpers::TechValues::getNormalizedIndustryTech(const EU4::Country& country) const
 {
-	return getNormalizedScore(getCountryIndustryTech(country), industryMax, industryMean);
+	Log(LogLevel::Debug) << country.getTag() << " " << country.getName() << " normalized score: " << getNormalizedScore(getCountryIndustryTech(country), industryMax, industryMedian);
+	return getNormalizedScore(getCountryIndustryTech(country), industryMax, industryMedian);
 }
 
 double helpers::TechValues::getCountryArmyTech(const EU4::Country& country)
 {
-	return country.getMilTech() +	country.getAdmTech() + country.getArmy();
+	return (country.getMilTech() + country.getAdmTech()) * (1 + country.getArmy() / 10);
 }
 
 double helpers::TechValues::getCountryNavyTech(const EU4::Country& country)
 {
-	return country.getMilTech() +	country.getDipTech() + country.getNavy();
+	return (country.getMilTech() + country.getDipTech()) * (1 + country.getNavy() / 10);
 }
 
 double helpers::TechValues::getCountryCommerceTech(const EU4::Country& country)
 {
-	return country.getAdmTech() +	country.getDipTech() + country.getCommerce();
+	return (country.getAdmTech() + country.getDipTech()) * (1 + country.getCommerce() / 10);
 }
 
 double helpers::TechValues::getCountryCultureTech(const EU4::Country& country)
 {
-	return country.getDipTech() + country.getCulture();
+	return country.getDipTech() * (1 + country.getCulture() / 10);
 }
 
 double helpers::TechValues::getCountryIndustryTech(const EU4::Country& country)
 {
-	return country.getAdmTech() +	country.getDipTech() + country.getMilTech() + country.getIndustry();
+	Log(LogLevel::Debug) << country.getName() << " ind score: " << (country.getAdmTech() + country.getDipTech() + country.getMilTech()) * ( 1.0 + country.getIndustry() / 10.0) << " indscore " << country.getIndustry();
+	return (country.getAdmTech() + country.getDipTech() + country.getMilTech()) * ( 1.0 + country.getIndustry() / 10.0);
 }
 
-double helpers::TechValues::getNormalizedScore(const double score, const double max, const double mean)
+double helpers::TechValues::getNormalizedScore(const double score, const double max, const double median)
 {
-	if (mean == max) return 1;
-	return (score - mean) / (max - mean);
+	if (median == max) return 1;
+	return (score - median) / (max - median);
+}
+
+double helpers::TechValues::dropOutliers(std::vector<double>& scores, const double mean)
+{
+	auto size = scores.size();
+	if (size == 0) return 0;
+	std::sort(scores.begin(), scores.end());
+	auto mid = size/2;
+
+	const auto medianRaw = size % 2 == 0 ? (scores[mid] + scores[mid-1]) / 2 : scores[mid];
+
+	// Drop outliers.
+	std::vector<double> filteredScores;
+	for (const auto& score: scores) if (std::abs(score - medianRaw) < 0.5 * medianRaw) filteredScores.emplace_back(score);
+	scores.swap(filteredScores);
+	
+	size = scores.size();
+	if (size == 0) return 0;
+	mid = size/2;
+	return size % 2 == 0 ? (scores[mid] + scores[mid-1]) / 2 : scores[mid];
 }

--- a/EU4toV2/Source/Helpers/TechValues.cpp
+++ b/EU4toV2/Source/Helpers/TechValues.cpp
@@ -5,7 +5,13 @@
 
 helpers::TechValues::TechValues(const std::map<std::string, std::shared_ptr<V2::Country>>& countries)
 {
-	
+	gatherScores(countries);
+	if (armyScores.empty()) return; // Well crap. Play dead and hope they go away.
+	calculateSteps();
+}
+
+void helpers::TechValues::gatherScores(const std::map<std::string, std::shared_ptr<V2::Country>>& countries)
+{
 	for (const auto& countryItr: countries)
 	{
 		const auto& country = countryItr.second;
@@ -17,9 +23,10 @@ helpers::TechValues::TechValues(const std::map<std::string, std::shared_ptr<V2::
 		cultureScores.emplace_back(getCountryCultureTech(*country->getSourceCountry()));
 		industryScores.emplace_back(getCountryIndustryTech(*country->getSourceCountry()));
 	}
+}
 
-	if (armyScores.empty()) return; // Well crap. Play dead and hope they go away.
-
+void helpers::TechValues::calculateSteps()
+{
 	// Drop all repeated scores, not using sets because we need indexes
 	std::sort(armyScores.begin(), armyScores.end());
 	armyScores.erase(std::unique(armyScores.begin(), armyScores.end()), armyScores.end());
@@ -40,6 +47,7 @@ helpers::TechValues::TechValues(const std::map<std::string, std::shared_ptr<V2::
 	commerceStep = 2.0 / commerceScores.size();
 	cultureStep = 2.0 / cultureScores.size();
 	industryStep = 2.0 / industryScores.size();	
+
 }
 
 bool helpers::TechValues::isValidCountryForTechConversion(const V2::Country& country)
@@ -52,7 +60,7 @@ double helpers::TechValues::getNormalizedArmyTech(const EU4::Country& country) c
 	const auto score = getCountryArmyTech(country);
 	const auto it = std::find(armyScores.begin(), armyScores.end(), score);
 	const auto index = std::distance(armyScores.begin(), it);
-	return (static_cast<long>(index) + 1) * armyStep - 1;
+	return (static_cast<double>(index) + 1) * armyStep - 1;
 }
 
 double helpers::TechValues::getNormalizedNavyTech(const EU4::Country& country) const
@@ -60,7 +68,7 @@ double helpers::TechValues::getNormalizedNavyTech(const EU4::Country& country) c
 	const auto score = getCountryNavyTech(country);
 	const auto it = std::find(navyScores.begin(), navyScores.end(), score);
 	const auto index = std::distance(navyScores.begin(), it);
-	return (static_cast<long>(index) + 1) * navyStep - 1;
+	return (static_cast<double>(index) + 1) * navyStep - 1;
 }
 
 double helpers::TechValues::getNormalizedCommerceTech(const EU4::Country& country) const
@@ -68,7 +76,7 @@ double helpers::TechValues::getNormalizedCommerceTech(const EU4::Country& countr
 	const auto score = getCountryCommerceTech(country);
 	const auto it = std::find(commerceScores.begin(), commerceScores.end(), score);
 	const auto index = std::distance(commerceScores.begin(), it);
-	return (static_cast<long>(index) + 1) * commerceStep - 1;
+	return (static_cast<double>(index) + 1) * commerceStep - 1;
 }
 
 double helpers::TechValues::getNormalizedCultureTech(const EU4::Country& country) const
@@ -76,7 +84,7 @@ double helpers::TechValues::getNormalizedCultureTech(const EU4::Country& country
 	const auto score = getCountryCultureTech(country);
 	const auto it = std::find(cultureScores.begin(), cultureScores.end(), score);
 	const auto index = std::distance(cultureScores.begin(), it);
-	return (static_cast<long>(index) + 1) * cultureStep - 1;
+	return (static_cast<double>(index) + 1) * cultureStep - 1;
 }
 
 double helpers::TechValues::getNormalizedIndustryTech(const EU4::Country& country) const
@@ -84,7 +92,7 @@ double helpers::TechValues::getNormalizedIndustryTech(const EU4::Country& countr
 	const auto score = getCountryIndustryTech(country);
 	const auto it = std::find(industryScores.begin(), industryScores.end(), score);
 	const auto index = std::distance(industryScores.begin(), it);
-	return (static_cast<long>(index) + 1) * industryStep - 1;
+	return (static_cast<double>(index) + 1) * industryStep - 1;
 }
 
 double helpers::TechValues::getCountryArmyTech(const EU4::Country& country)

--- a/EU4toV2/Source/Helpers/TechValues.h
+++ b/EU4toV2/Source/Helpers/TechValues.h
@@ -42,6 +42,9 @@ namespace helpers
 		[[nodiscard]] static double getCountryCultureTech(const EU4::Country& country);
 		[[nodiscard]] static double getCountryIndustryTech(const EU4::Country& country);
 
+		void gatherScores(const std::map<std::string, std::shared_ptr<V2::Country>>& countries);
+		void calculateSteps();
+
 		double armyStep = 0;
 		double navyStep = 0;
 		double commerceStep = 0;

--- a/EU4toV2/Source/Helpers/TechValues.h
+++ b/EU4toV2/Source/Helpers/TechValues.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <memory>
+#include <vector>
 
 namespace EU4
 {
@@ -39,14 +40,14 @@ namespace helpers
 		[[nodiscard]] static double getCountryCommerceTech(const EU4::Country& country);
 		[[nodiscard]] static double getCountryCultureTech(const EU4::Country& country);
 		[[nodiscard]] static double getCountryIndustryTech(const EU4::Country& country);
-		[[nodiscard]] static double getNormalizedScore(double score, double max, double mean);
+		[[nodiscard]] static double getNormalizedScore(double score, double min, double median);
+		[[nodiscard]] static double dropOutliers(std::vector<double>& scores, double mean);
 
 		double armyMax = 0;
 		double navyMax = 0;
 		double commerceMax = 0;
 		double cultureMax = 0;
 		double industryMax = 0;
-
 		double armyMean = 0;
 		double navyMean = 0;
 		double commerceMean = 0;

--- a/EU4toV2/Source/Helpers/TechValues.h
+++ b/EU4toV2/Source/Helpers/TechValues.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <set>
 
 namespace EU4
 {
@@ -40,19 +41,18 @@ namespace helpers
 		[[nodiscard]] static double getCountryCommerceTech(const EU4::Country& country);
 		[[nodiscard]] static double getCountryCultureTech(const EU4::Country& country);
 		[[nodiscard]] static double getCountryIndustryTech(const EU4::Country& country);
-		[[nodiscard]] static double getNormalizedScore(double score, double min, double median);
-		[[nodiscard]] static double dropOutliers(std::vector<double>& scores, double mean);
 
-		double armyMax = 0;
-		double navyMax = 0;
-		double commerceMax = 0;
-		double cultureMax = 0;
-		double industryMax = 0;
-		double armyMean = 0;
-		double navyMean = 0;
-		double commerceMean = 0;
-		double cultureMean = 0;
-		double industryMean = 0;
+		double armyStep = 0;
+		double navyStep = 0;
+		double commerceStep = 0;
+		double cultureStep = 0;
+		double industryStep = 0;
+		std::vector<double> armyScores;
+		std::vector<double> navyScores;
+		std::vector<double> commerceScores;
+		std::vector<double> cultureScores;
+		std::vector<double> industryScores;
+
 	};
 }
 


### PR DESCRIPTION
Too few countries and in too obscure conditions would get higher tech levels - most notably access to mechanical_production - and this would deadlock entire economy until 1840s. On a test example two OPMs were only countries with high enough industry score to break 0.6 required for machine parts. Another example had a single 2-state country.

I've swapped normalized rankings for a score system where all civilized nations are linearly distributed across the range (and can share spots), so this will greatly increase tech diversity and tech availability.

Uncivilized nations are not affected.