### PR TITLE
Absorption

### DIFF
--- a/EU4ToVic2Tests/ConfigurationTests.cpp
+++ b/EU4ToVic2Tests/ConfigurationTests.cpp
@@ -338,7 +338,7 @@ TEST(EU4ToVic2_ConfigurationTests, MaxLiteracyDefaultsToOne)
 TEST(EU4ToVic2_ConfigurationTests, MaxLiteracyCanBeSet)
 {
 	Configuration testConfiguration;
-	std::stringstream input("max_literacy = 0.5");
+	std::stringstream input("max_literacy = 50");
 	testConfiguration.instantiate(input, fakeDoesFolderExist, fakeDoesFileExist);
 
 	ASSERT_EQ(testConfiguration.getMaxLiteracy(), 0.5);
@@ -371,17 +371,17 @@ TEST(EU4ToVic2_ConfigurationTests, LibertyThresholdDefaultsToFifty)
 	std::stringstream input("");
 	testConfiguration.instantiate(input, fakeDoesFolderExist, fakeDoesFileExist);
 
-	ASSERT_EQ(testConfiguration.getLibertyThreshold(), 50.0);
+	ASSERT_EQ(testConfiguration.getLibertyThreshold(), Configuration::LIBERTYDESIRE::Loyal);
 }
 
 
 TEST(EU4ToVic2_ConfigurationTests, LibertyThresholdCanBeSet)
 {
 	Configuration testConfiguration;
-	std::stringstream input("libertyThreshold = 50.0");
+	std::stringstream input("liberty_threshold = 2");
 	testConfiguration.instantiate(input, fakeDoesFolderExist, fakeDoesFileExist);
 
-	ASSERT_EQ(testConfiguration.getLibertyThreshold(), 50.0);
+	ASSERT_EQ(testConfiguration.getLibertyThreshold(), Configuration::LIBERTYDESIRE::Disloyal);
 }
 
 

--- a/EU4toV2/Data_Files/Eu4ToVic2DefaultConfiguration.xml
+++ b/EU4toV2/Data_Files/Eu4ToVic2DefaultConfiguration.xml
@@ -31,9 +31,9 @@
 					<friendlyName>Max Literacy</friendlyName>
 					<description>The maximum literacy a nation will start with. Default 100%</description>
 					<hasDirectlyEditableValue>true</hasDirectlyEditableValue>
-					<value>1</value>
-					<minValue>0.1</minValue>
-					<maxValue>1</maxValue>
+					<value>100</value>
+					<minValue>1</minValue>
+					<maxValue>100</maxValue>
 				</preference>
 				<preference>
 					<name>remove_type</name>
@@ -61,12 +61,37 @@
 					</entryOptions>
 				</preference>
 				<preference>
+					<name>absorb_colonies</name>
+					<friendlyName>Turn Colonial Nations into territories?</friendlyName>
+					<description>How should we handle one's colonial nations?</description>
+					<entryOptions>
+						<entryOption>
+							<name>1</name>
+							<friendlyName>1 - Never, they are puppets</friendlyName>
+							<description>All will be independent</description>
+							<isDefault>true</isDefault>
+						</entryOption>
+						<entryOption>
+							<name>2</name>
+							<friendlyName>2 - Sometimes, see liberty desire</friendlyName>
+							<description>Set the threshold manually</description>
+							<isDefault>false</isDefault>
+						</entryOption>
+						<entryOption>
+							<name>3</name>
+							<friendlyName>3 - All, even disloyal ones</friendlyName>
+							<description>Integrate every dependant colonial nation</description>
+							<isDefault>false</isDefault>
+						</entryOption>
+					</entryOptions>
+				</preference>				
+				<preference>
 					<name>liberty_threshold</name>
-					<friendlyName>Liberty threshold for Colonies</friendlyName>
-					<description>The threshold value for when colonies are not absorbed. Default 50% (loyal colonies absorbed)</description>
+					<friendlyName>If "Sometimes", when exactly?</friendlyName>
+					<description>The threshold value for when colonies are not absorbed. Default 25% liberty desire.</description>
 					<hasDirectlyEditableValue>true</hasDirectlyEditableValue>
-					<value>50</value>
-					<minValue>1</minValue>
+					<value>25</value>
+					<minValue>0</minValue>
 					<maxValue>100</maxValue>
 				</preference>
 				<preference>

--- a/EU4toV2/Data_Files/Eu4ToVic2DefaultConfiguration.xml
+++ b/EU4toV2/Data_Files/Eu4ToVic2DefaultConfiguration.xml
@@ -73,7 +73,7 @@
 						</entryOption>
 						<entryOption>
 							<name>2</name>
-							<friendlyName>2 - Sometimes, see liberty desire</friendlyName>
+							<friendlyName>2 - Sometimes, by attitude</friendlyName>
 							<description>Set the threshold manually</description>
 							<isDefault>false</isDefault>
 						</entryOption>
@@ -88,11 +88,27 @@
 				<preference>
 					<name>liberty_threshold</name>
 					<friendlyName>If "Sometimes", when exactly?</friendlyName>
-					<description>The threshold value for when colonies are not absorbed. Default 25% liberty desire.</description>
-					<hasDirectlyEditableValue>true</hasDirectlyEditableValue>
-					<value>25</value>
-					<minValue>0</minValue>
-					<maxValue>100</maxValue>
+					<description>The threshold attitude for when colonies are absorbed. Default is loyal.</description>
+					<entryOptions>
+						<entryOption>
+							<name>1</name>
+							<friendlyName>1 - Absorb Loyal only</friendlyName>
+							<description>Only Loyal colonies</description>
+							<isDefault>true</isDefault>
+						</entryOption>
+						<entryOption>
+							<name>2</name>
+							<friendlyName>2 - Absorb Disloyal too</friendlyName>
+							<description>Disloyal colonies absorbed too.</description>
+							<isDefault>false</isDefault>
+						</entryOption>
+						<entryOption>
+							<name>3</name>
+							<friendlyName>3 - Absorb Rebellious as well</friendlyName>
+							<description>All colonies are absorbed</description>
+							<isDefault>false</isDefault>
+						</entryOption>
+					</entryOptions>
 				</preference>
 				<preference>
 					<name>pop_shaping</name>

--- a/EU4toV2/Source/Configuration.cpp
+++ b/EU4toV2/Source/Configuration.cpp
@@ -57,9 +57,9 @@ void Configuration::instantiate(std::istream& theStream, bool (*doesFolderExist)
 		LOG(LogLevel::Info) << "Absorb Colonies: " << absorbInt.getInt();
 		});
 	registerKeyword("liberty_threshold", [this](const std::string& unused, std::istream& theStream){
-		const commonItems::singleDouble libertyThresholdDouble(theStream);
-		libertyThreshold = libertyThresholdDouble.getDouble();
-		LOG(LogLevel::Info) << "Liberty Treshold: " << libertyThreshold;
+		const commonItems::singleInt libertyThresholdInt(theStream);
+		libertyThreshold = LIBERTYDESIRE(libertyThresholdInt.getInt());
+		LOG(LogLevel::Info) << "Liberty Treshold: " << libertyThresholdInt.getInt();
 	});
 	registerKeyword("pop_shaping", [this](const std::string& unused, std::istream& theStream){
 		const commonItems::singleInt popShapingInt(theStream);

--- a/EU4toV2/Source/Configuration.cpp
+++ b/EU4toV2/Source/Configuration.cpp
@@ -44,13 +44,18 @@ void Configuration::instantiate(std::istream& theStream, bool (*doesFolderExist)
 	registerKeyword("reset_provinces", commonItems::ignoreItem);
 	registerKeyword("max_literacy", [this](const std::string& unused, std::istream& theStream){
 		const commonItems::singleDouble maxLiteracyDouble(theStream);
-		MaxLiteracy = maxLiteracyDouble.getDouble();
+		MaxLiteracy = maxLiteracyDouble.getDouble() / 100;
 		LOG(LogLevel::Info) << "Max Literacy: " << MaxLiteracy;
 	});
 	registerKeyword("remove_type", [this](const std::string& unused, std::istream& theStream){
 		const commonItems::singleInt removeTypeString(theStream);
 		removeType = DEADCORES(removeTypeString.getInt());
 	});
+	registerKeyword("absorb_colonies", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleInt absorbInt(theStream);
+		absorbColonies = ABSORBCOLONIES(absorbInt.getInt());
+		LOG(LogLevel::Info) << "Absorb Colonies: " << absorbInt.getInt();
+		});
 	registerKeyword("liberty_threshold", [this](const std::string& unused, std::istream& theStream){
 		const commonItems::singleDouble libertyThresholdDouble(theStream);
 		libertyThreshold = libertyThresholdDouble.getDouble();

--- a/EU4toV2/Source/Configuration.h
+++ b/EU4toV2/Source/Configuration.h
@@ -32,6 +32,7 @@ class Configuration: commonItems::parser
 		enum class POPSHAPES { Vanilla = 1, PopShaping = 2, Extreme = 3 };
 		enum class COREHANDLES { DropNone = 1, DropNational = 2, DropUnions = 3, DropAll = 4 };
 		enum class EUROCENTRISM { VanillaImport = 1, EuroCentric = 2 };
+		enum class ABSORBCOLONIES { AbsorbNone = 1, AbsorbSome = 2, AbsorbAll = 3 };
 
 		[[nodiscard]] auto getPopShaping() const { return popShaping; }
 		[[nodiscard]] auto getCoreHandling() const { return coreHandling; }
@@ -41,6 +42,7 @@ class Configuration: commonItems::parser
 		[[nodiscard]] auto getMaxLiteracy() const { return MaxLiteracy; }
 		[[nodiscard]] auto getLibertyThreshold() const { return libertyThreshold; }
 		[[nodiscard]] auto getPopShapingFactor() const { return popShapingFactor; }
+		[[nodiscard]] auto getAbsorbColonies() const { return absorbColonies; }
 		[[nodiscard]] auto getDebug() const { return debug; }
 		[[nodiscard]] auto getRandomiseRgos() const { return randomiseRgos; }
 		[[nodiscard]] auto getConvertAll() const { return convertAll; }
@@ -86,6 +88,7 @@ class Configuration: commonItems::parser
 		COREHANDLES coreHandling = COREHANDLES::DropNone;
 		DEADCORES removeType = DEADCORES::DeadCores;
 		EUROCENTRISM euroCentric = EUROCENTRISM::VanillaImport;
+		ABSORBCOLONIES absorbColonies = ABSORBCOLONIES::AbsorbNone;
 		double popShapingFactor = 50.0;
 		bool debug = false;
 		bool randomiseRgos = false;

--- a/EU4toV2/Source/Configuration.h
+++ b/EU4toV2/Source/Configuration.h
@@ -33,6 +33,7 @@ class Configuration: commonItems::parser
 		enum class COREHANDLES { DropNone = 1, DropNational = 2, DropUnions = 3, DropAll = 4 };
 		enum class EUROCENTRISM { VanillaImport = 1, EuroCentric = 2 };
 		enum class ABSORBCOLONIES { AbsorbNone = 1, AbsorbSome = 2, AbsorbAll = 3 };
+		enum class LIBERTYDESIRE { Loyal = 1, Disloyal = 2, Rebellious = 3 };
 
 		[[nodiscard]] auto getPopShaping() const { return popShaping; }
 		[[nodiscard]] auto getCoreHandling() const { return coreHandling; }
@@ -83,7 +84,7 @@ class Configuration: commonItems::parser
 		std::string Vic2DocumentsPath;
 		std::string resetProvinces = "no";
 		double MaxLiteracy = 1.0;
-		double libertyThreshold = 50.0;
+		LIBERTYDESIRE libertyThreshold = LIBERTYDESIRE::Loyal;
 		POPSHAPES popShaping = POPSHAPES::Vanilla;
 		COREHANDLES coreHandling = COREHANDLES::DropNone;
 		DEADCORES removeType = DEADCORES::DeadCores;

--- a/EU4toV2/Source/EU4World/Country/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/Country/EU4Country.cpp
@@ -466,65 +466,64 @@ void EU4::Country::determineInvestments(const mappers::IdeaEffectMapper& ideaEff
 
 void EU4::Country::determineLibertyDesire()
 {
-	if (colony && libertyDesire > 0)
+	if (!colony) return;
+	
+	const auto& relationship = relations.find(overlord);
+	if (relationship != relations.end())
 	{
-		const auto& relationship = relations.find(overlord);
-		if (relationship != relations.end())
+		const auto& attitude = relationship->second.getAttitude();
+		if (attitude == "attitude_rebellious")
 		{
-			const auto& attitude = relationship->second.getAttitude();
-			if (attitude == "attitude_rebellious")
-			{
-				libertyDesire = 95.0;
-			}
-			else if (attitude == "attitude_disloyal" || attitude == "attitude_disloyal_vassal")	// _vassal for pre-1.14 games
-			{
-				libertyDesire = 90.0;
-			}
-			else if (attitude == "attitude_outraged")
-			{
-				libertyDesire = 85.0;
-			}
-			else if (attitude == "attitude_rivalry")
-			{
-				libertyDesire = 80.0;
-			}
-			else if (attitude == "attitude_hostile")
-			{
-				libertyDesire = 75.0;
-			}
-			else if (attitude == "attitude_threatened")
-			{
-				libertyDesire = 65.0;
-			}
-			else if (attitude == "attitude_neutral")
-			{
-				libertyDesire = 50.0;
-			}
-			else if (attitude == "attitude_defensive")
-			{
-				libertyDesire = 35.0;
-			}
-			else if (attitude == "attitude_domineering")
-			{
-				libertyDesire = 20.0;
-			}
-			else if (attitude == "attitude_protective")
-			{
-				libertyDesire = 15.0;
-			}
-			else if (attitude == "attitude_allied" || attitude == "attitude_friendly")
-			{
-				libertyDesire = 10.0;
-			}
-			else if (attitude == "attitude_loyal" || attitude == "attitude_overlord" || attitude == "attitude_vassal")	// _vassal for pre-1.14 games
-			{
-				libertyDesire = 5.0;
-			}
-			else
-			{
-				LOG(LogLevel::Warning) << "Unknown attitude type " << attitude << " while setting liberty desire for " << tag;
-				libertyDesire = 95.0;
-			}
+			libertyDesire = 95.0;
+		}
+		else if (attitude == "attitude_disloyal" || attitude == "attitude_disloyal_vassal")	// _vassal for pre-1.14 games
+		{
+			libertyDesire = 90.0;
+		}
+		else if (attitude == "attitude_outraged")
+		{
+			libertyDesire = 85.0;
+		}
+		else if (attitude == "attitude_rivalry")
+		{
+			libertyDesire = 80.0;
+		}
+		else if (attitude == "attitude_hostile")
+		{
+			libertyDesire = 75.0;
+		}
+		else if (attitude == "attitude_threatened")
+		{
+			libertyDesire = 65.0;
+		}
+		else if (attitude == "attitude_neutral")
+		{
+			libertyDesire = 50.0;
+		}
+		else if (attitude == "attitude_defensive")
+		{
+			libertyDesire = 35.0;
+		}
+		else if (attitude == "attitude_domineering")
+		{
+			libertyDesire = 20.0;
+		}
+		else if (attitude == "attitude_protective")
+		{
+			libertyDesire = 15.0;
+		}
+		else if (attitude == "attitude_allied" || attitude == "attitude_friendly")
+		{
+			libertyDesire = 10.0;
+		}
+		else if (attitude == "attitude_loyal" || attitude == "attitude_overlord" || attitude == "attitude_vassal")	// _vassal for pre-1.14 games
+		{
+			libertyDesire = 5.0;
+		}
+		else
+		{
+			LOG(LogLevel::Warning) << "Unknown attitude type " << attitude << " while setting liberty desire for " << tag;
+			libertyDesire = 95.0;
 		}
 	}
 }

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
@@ -49,7 +49,9 @@ void V2::Diplomacy::convertDiplomacy(
 			country2->second->setColonyOverlord(V2Tag1);
 			
 			// Do we annex or not?
-			if (country2->second->getSourceCountry()->getLibertyDesire() < theConfiguration.getLibertyThreshold())
+			if (theConfiguration.getAbsorbColonies() == Configuration::ABSORBCOLONIES::AbsorbAll || 
+				theConfiguration.getAbsorbColonies() == Configuration::ABSORBCOLONIES::AbsorbSome &&
+					country2->second->getSourceCountry()->getLibertyDesire() < theConfiguration.getLibertyThreshold())
 			{
 				LOG(LogLevel::Info) << " - " << country1->second->getTag() << " is absorbing " << country2->second->getTag() <<
 					" (" << country2->second->getSourceCountry()->getLibertyDesire() << " vs " << theConfiguration.getLibertyThreshold() << " liberty desire)";

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
@@ -47,14 +47,20 @@ void V2::Diplomacy::convertDiplomacy(
 		if (agreementMapper.isAgreementInColonies(agreement.getAgreementType()))
 		{
 			country2->second->setColonyOverlord(V2Tag1);
+
+			std::map<Configuration::LIBERTYDESIRE, double> libertyMap = {
+				{Configuration::LIBERTYDESIRE::Loyal, 50.0},
+				{Configuration::LIBERTYDESIRE::Disloyal, 95.0},
+				{Configuration::LIBERTYDESIRE::Rebellious, 100.0},
+			};
 			
 			// Do we annex or not?
 			if (theConfiguration.getAbsorbColonies() == Configuration::ABSORBCOLONIES::AbsorbAll || 
 				theConfiguration.getAbsorbColonies() == Configuration::ABSORBCOLONIES::AbsorbSome &&
-					country2->second->getSourceCountry()->getLibertyDesire() < theConfiguration.getLibertyThreshold())
+					country2->second->getSourceCountry()->getLibertyDesire() < libertyMap[theConfiguration.getLibertyThreshold()])
 			{
 				LOG(LogLevel::Info) << " - " << country1->second->getTag() << " is absorbing " << country2->second->getTag() <<
-					" (" << country2->second->getSourceCountry()->getLibertyDesire() << " vs " << theConfiguration.getLibertyThreshold() << " liberty desire)";
+					" (" << country2->second->getSourceCountry()->getLibertyDesire() << " vs " << libertyMap[theConfiguration.getLibertyThreshold()] << " liberty desire)";
 				country1->second->absorbColony(*country2->second);
 				for (auto& agreement2 : eu4agreements)
 				{
@@ -67,7 +73,7 @@ void V2::Diplomacy::convertDiplomacy(
 			}
 			
 			LOG(LogLevel::Info) << " - " << country1->second->getTag() << " is not absorbing " << country2->second->getTag() <<
-				" (" << country2->second->getSourceCountry()->getLibertyDesire() << " vs " << theConfiguration.getLibertyThreshold() << " liberty desire)";
+				" (" << country2->second->getSourceCountry()->getLibertyDesire() << " vs " << libertyMap[theConfiguration.getLibertyThreshold()] << " liberty desire)";
 		}
 
 		if (agreementMapper.isAgreementInOnesiders(agreement.getAgreementType()))


### PR DESCRIPTION
Fix for #22

Liberty desire is a calculated value not stored in the save game. The "liberty_desire" in the save is a weird number which I believe is only generated through events and dissolves rapidly, and only factors in along with others (army comparison, opinion modifer etc.) when calculating the final score.

Thus, going through relationship attitude as we currently do is the correct path, although only values that actually exist for colonies are "loyal", "disloyal" or "rebellious", so the options result in 5, 90 and 95.

There's not much we can do about this, but additional converter option will simplify the selection for players. There is no need to deceive players entering "62" into liberty desire thinking their Brazil sitting at 63 will be excluded from integration, since our values are not identical to EU4 ones.