### PR TITLE
Lower literacy for earlier conversion dates.

### DIFF
--- a/EU4toV2/Source/Configuration.h
+++ b/EU4toV2/Source/Configuration.h
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+const date HARD_ENDING_DATE("1836.1.1");
+const date FUTURE_DATE("2000.1.1");
+
 class Configuration: commonItems::parser
 {
 	public:

--- a/EU4toV2/Source/EU4World/Provinces/ProvinceHistory.cpp
+++ b/EU4toV2/Source/EU4World/Provinces/ProvinceHistory.cpp
@@ -4,9 +4,6 @@
 #include "Log.h"
 #include "ParserHelpers.h"
 
-const date HARD_ENDING_DATE("1836.1.1");
-const date FUTURE_DATE("2000.1.1");
-
 EU4::ProvinceHistory::ProvinceHistory(std::istream& theStream)
 {
 	registerKeyword("owner", [this](const std::string& unused, std::istream & theStream) {

--- a/EU4toV2/Source/V2World/Country/Country.cpp
+++ b/EU4toV2/Source/V2World/Country/Country.cpp
@@ -706,6 +706,13 @@ void V2::Country::newCivConversionMethod(double topTech, int topInstitutions, co
 
 	details.literacy *= theConfiguration.getMaxLiteracy() * (pow(10, civLevel / 100 * 0.9 + 0.1) / 10);
 
+	// drop nominal literacy according to starting date.
+
+	const auto diffYear = std::fmax(theConfiguration.getLastEU4Date().diffInYears(date("0.1.1")), 0);
+	const auto yearFactor = (0.1 + 4614700 * diffYear) / (1 + static_cast<float>(103810000) * diffYear - 54029 * pow(diffYear, 2));
+
+	details.literacy *= yearFactor;
+
 	if (civLevel == 100) details.civilized = true;
 
 	if (details.civilized == false)

--- a/EU4toV2/Source/V2World/Country/Country.cpp
+++ b/EU4toV2/Source/V2World/Country/Country.cpp
@@ -706,10 +706,22 @@ void V2::Country::newCivConversionMethod(double topTech, int topInstitutions, co
 
 	details.literacy *= theConfiguration.getMaxLiteracy() * (pow(10, civLevel / 100 * 0.9 + 0.1) / 10);
 
-	// drop nominal literacy according to starting date.
-
-	const auto diffYear = std::fmax(theConfiguration.getLastEU4Date().diffInYears(date("0.1.1")), 0);
-	const auto yearFactor = (0.1 + 4614700 * diffYear) / (1 + static_cast<float>(103810000) * diffYear - 54029 * pow(diffYear, 2));
+	/*
+	Drop nominal literacy according to starting date. The curve is crafted to hit the following literacy percentage points:
+	1836: 1
+	1821: 0.85
+	1750: 0.5
+	1650: 0.3
+	1490: 0.2
+	1350: 0.15
+	It will fail to hit those points exactly but won't err by much.
+	*/
+	
+	auto lastDate = theConfiguration.getLastEU4Date();
+	if (lastDate > HARD_ENDING_DATE) lastDate = HARD_ENDING_DATE;
+	
+	const auto currentYear = std::fmax(lastDate.diffInYears(date("0.1.1")), 0);
+	const auto yearFactor = (0.1 + 4'614'700 * currentYear) / (1 + 103'810'000.0f * currentYear - 54'029 * pow(currentYear, 2));
 
 	details.literacy *= yearFactor;
 


### PR DESCRIPTION
No reduction at 1836, 15%  at 1821, 50% 1750, and then it slowly degrades to 20% at 1490 and 15% at 1356.