### PR TITLE
Industrialization review

### DIFF
--- a/EU4toV2/Data_Files/Eu4ToVic2DefaultConfiguration.xml
+++ b/EU4toV2/Data_Files/Eu4ToVic2DefaultConfiguration.xml
@@ -184,13 +184,13 @@
 							<name>1</name>
 							<friendlyName>1 - Use EU4 institutions and tech</friendlyName>
 							<description>Use defaults</description>
-							<isDefault>true</isDefault>
+							<isDefault>false</isDefault>
 						</entryOption>
 						<entryOption>
 							<name>2</name>
 							<friendlyName>2 - Time to rule the waves!</friendlyName>
 							<description>Configurable via techgroups.txt</description>
-							<isDefault>false</isDefault>
+							<isDefault>true</isDefault>
 						</entryOption>
 					</entryOptions>
 				</preference>

--- a/EU4toV2/Data_Files/configurables/starting_factories.txt
+++ b/EU4toV2/Data_Files/configurables/starting_factories.txt
@@ -1,20 +1,20 @@
 # These are factories distributed to civilized countries at game start.
 
-fabric_factory = 5
-ammunition_factory = 3
-steel_factory = 3
+fabric_factory = 6
+steel_factory = 6
+ammunition_factory = 4
 paper_mill = 3
-cement_factory = 3
-lumber_mill = 2
-regular_clothes_factory = 2
+small_arms_factory = 3
+canned_food_factory = 3
+cement_factory = 2
 explosives_factory = 2
-small_arms_factory = 2
 glass_factory = 2
 artillery_factory = 2
 clipper_shipyard = 2
-canned_food_factory = 2
+lumber_mill = 1
+regular_clothes_factory = 1
 furniture_factory = 1
-liquor_distillery = 1
 luxury_furniture_factory = 1
 winery = 1
 luxury_clothes_factory = 1
+steamer_shipyard = 1

--- a/EU4toV2/Source/EU4World/Army/EU4Regiment.h
+++ b/EU4toV2/Source/EU4World/Army/EU4Regiment.h
@@ -40,7 +40,8 @@ namespace EU4
 		{ REGIMENTCATEGORY::heavy_ship, "heavy_ship" },
 		{ REGIMENTCATEGORY::light_ship, "light_ship" },
 		{ REGIMENTCATEGORY::galley, "galley" },
-		{ REGIMENTCATEGORY::transport, "transport" }
+		{ REGIMENTCATEGORY::transport, "transport" },
+		{ REGIMENTCATEGORY::num_reg_categories, "unassigned category!" }
 	};
 
 	class EU4Regiment : public  commonItems::parser

--- a/EU4toV2/Source/EU4World/Country/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/Country/EU4Country.cpp
@@ -604,9 +604,8 @@ void EU4::Country::resolveRegimentTypes(const mappers::UnitTypeMapper& unitTypeM
 	for (auto& itr: armies) itr.resolveRegimentTypes(unitTypeMapper);
 }
 
-int EU4::Country::getManufactoryCount() const
+void EU4::Country::buildManufactoryCount(const std::map<std::string, std::shared_ptr<Country>>& theCountries)
 {
-	auto mfgCount = 0;
 	for (const auto& province: provinces)
 	{
 		//TODO: Dump buildings and values into own parser - duplication at V2::Province
@@ -619,7 +618,19 @@ int EU4::Country::getManufactoryCount() const
 		if (province->hasBuilding("mills")) ++mfgCount;
 		if (province->hasBuilding("furnace")) mfgCount += 3;
 	}
-	return mfgCount;
+	if (!overlord.empty())
+	{
+		const auto transferCount = mfgCount - lround(mfgCount / 2);
+		mfgTransfer -= transferCount;
+		const auto& overlordCountry = theCountries.find(overlord);
+		if (overlordCountry != theCountries.end()) overlordCountry->second->increaseMfgTransfer(transferCount);
+	}
+}
+
+double EU4::Country::getManufactoryDensity() const
+{
+	if (provinces.empty()) return 0;
+	return static_cast<double>(mfgCount) / provinces.size();
 }
 
 void EU4::Country::eatCountry(Country& target)

--- a/EU4toV2/Source/EU4World/Country/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/Country/EU4Country.cpp
@@ -10,6 +10,7 @@
 #include "EU4CountryFlags.h"
 #include "EU4Modifier.h"
 #include "EU4ActiveIdeas.h"
+#include <cmath>
 
 EU4::Country::Country(
 	std::string countryTag,

--- a/EU4toV2/Source/EU4World/Country/EU4Country.h
+++ b/EU4toV2/Source/EU4World/Country/EU4Country.h
@@ -53,6 +53,8 @@ namespace EU4
 		void dropMinorityCultures();
 		void filterLeaders();
 		void resolveRegimentTypes(const mappers::UnitTypeMapper& unitTypeMapper);
+		void buildManufactoryCount(const std::map<std::string, std::shared_ptr<Country>>& theCountries);
+		void increaseMfgTransfer(const int increase) { mfgTransfer += increase; }
 
 		[[nodiscard]] const auto& getTag() const { return tag; }
 		[[nodiscard]] auto getCapital() const { return capital; }
@@ -95,6 +97,7 @@ namespace EU4
 		[[nodiscard]] auto isColony() const { return colony; }
 		[[nodiscard]] auto getLibertyDesire() const { return libertyDesire; }
 		[[nodiscard]] auto isRevolutionary() const { return revolutionary; }
+		[[nodiscard]] auto getManufactoryCount() const { return mfgCount + mfgTransfer; }
 		[[nodiscard]] const auto& getRandomName() const { return randomName; }
 		[[nodiscard]] const auto& getName() const { return name; }
 				
@@ -122,8 +125,8 @@ namespace EU4
 		[[nodiscard]] bool hasModifier(const std::string&) const;
 		[[nodiscard]] bool hasNationalIdea(const std::string&) const;
 		[[nodiscard]] bool hasFlag(const std::string&) const;
-		[[nodiscard]] int getManufactoryCount() const;
 		[[nodiscard]] int numEmbracedInstitutions() const;
+		[[nodiscard]] double getManufactoryDensity() const;
 
 	private:
 		void determineJapaneseRelations();
@@ -200,6 +203,8 @@ namespace EU4
 		std::string randomName; // the new name of this nation in Random World
 		bool revolutionary = false; // does this country wave the glorious tri-colored banner of the revolution
 		std::set<std::string> governmentReforms;
+		int mfgCount = 0;
+		int mfgTransfer = 0;
 
 		// Localization attributes
 		std::string	name; // the name of this country

--- a/EU4toV2/Source/EU4World/World.cpp
+++ b/EU4toV2/Source/EU4World/World.cpp
@@ -181,6 +181,9 @@ EU4::World::World(const mappers::IdeaEffectMapper& ideaEffectMapper)
 	LOG(LogLevel::Info) << "-> Merging Nations";
 	mergeNations();
 
+	LOG(LogLevel::Info) << "-> Calculating Industry";
+	calculateIndustry();
+
 	LOG(LogLevel::Info) << "-> Viva la revolution!";
 	loadRevolutionTarget();
 	if (!revolutionTargetString.empty())
@@ -206,6 +209,14 @@ EU4::World::World(const mappers::IdeaEffectMapper& ideaEffectMapper)
 		removeLandlessNations();
 	}
 	LOG(LogLevel::Info) << "*** Good-bye EU4, you served us well. ***";
+}
+
+void EU4::World::calculateIndustry() const
+{
+	for (const auto& country: theCountries)
+	{
+		country.second->buildManufactoryCount(theCountries);
+	}
 }
 
 void EU4::World::buildPopRatios() const

--- a/EU4toV2/Source/EU4World/World.cpp
+++ b/EU4toV2/Source/EU4World/World.cpp
@@ -140,6 +140,7 @@ EU4::World::World(const mappers::IdeaEffectMapper& ideaEffectMapper)
 	clearRegisteredKeywords();
 
 	cultureGroupsMapper.initForEU4();
+	unitTypeMapper.initUnitTypeMapper();
 
 	LOG(LogLevel::Info) << "*** Building world ***";
 	LOG(LogLevel::Info) << "-> Loading Empires";

--- a/EU4toV2/Source/EU4World/World.h
+++ b/EU4toV2/Source/EU4World/World.h
@@ -66,6 +66,7 @@ namespace EU4
 		void catalogueNativeCultures();
 		void generateNeoCultures();
 		void buildPopRatios() const;
+		void calculateIndustry() const;
 		std::string generateNeoCulture(const std::string& superRegionName, const std::string& oldCultureName);
 		bool uncompressSave();
 		

--- a/EU4toV2/Source/Mappers/UnitTypes/UnitTypeMapper.cpp
+++ b/EU4toV2/Source/Mappers/UnitTypes/UnitTypeMapper.cpp
@@ -6,7 +6,7 @@
 #include "../../Configuration.h"
 
 
-mappers::UnitTypeMapper::UnitTypeMapper()
+void mappers::UnitTypeMapper::initUnitTypeMapper()
 {
 	LOG(LogLevel::Info) << "Parsing unit strengths from EU4 installation.";
 

--- a/EU4toV2/Source/Mappers/UnitTypes/UnitTypeMapper.h
+++ b/EU4toV2/Source/Mappers/UnitTypes/UnitTypeMapper.h
@@ -11,7 +11,8 @@ namespace mappers
 	class UnitTypeMapper : commonItems::parser
 	{
 	public:
-		UnitTypeMapper();
+		UnitTypeMapper() = default;
+		void initUnitTypeMapper();
 		
 		[[nodiscard]] const auto& getUnitTypeMap() const { return unitTypeMap; }
 

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -899,7 +899,7 @@ void V2::World::allocateFactories(const EU4::World& sourceWorld)
 		admMean += (admTech - admMean) / num;
 		++num;
 	}
-
+	
 	// give all extant civilized nations an industrial score
 	std::deque<std::pair<double, std::shared_ptr<Country>>> weightedCountries;
 	for (const auto& country : countries)
@@ -913,7 +913,8 @@ void V2::World::allocateFactories(const EU4::World& sourceWorld)
 		// modified manufactory weight follows diminishing returns curve y = x^(3/4)+log((x^2)/5+1)
 		const auto manuCount = sourceCountry->getManufactoryCount();
 		const auto manuWeight = pow(manuCount, 0.75) + log1p(static_cast<double>(pow(manuCount, 2)) / 5.0);
-		auto industryWeight = sourceCountry->getAdmTech() - admMean + manuWeight;
+		const auto manuDensity = sourceCountry->getManufactoryDensity();
+		auto industryWeight = (sourceCountry->getAdmTech() - admMean) * 5 + manuWeight * manuDensity;
 		// having one manufactory and average tech is not enough; you must have more than one, or above-average tech
 		if (industryWeight > 1.0)
 		{

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -899,7 +899,7 @@ void V2::World::allocateFactories(const EU4::World& sourceWorld)
 		admMean += (admTech - admMean) / num;
 		++num;
 	}
-	
+
 	// give all extant civilized nations an industrial score
 	std::deque<std::pair<double, std::shared_ptr<Country>>> weightedCountries;
 	for (const auto& country : countries)


### PR DESCRIPTION
- Puppets now transfer half their manufactories to overlord for purposes of starting industry weight and factory distribution.
- effects of being ahead or behind with admin tech on industry are now multiplied by 5 as previous values did next to nothing.
- manufactory weight is multiplied by manufactory density to better represent industrialization centers.
- Starting factory counts have been updated to exactly match vanilla.

Unrelated:
- unit type mapper inited too early, not grabbing mod unit definitions.