### PR TITLE
Expanding countries catch regex

### DIFF
--- a/EU4toV2/Source/EU4World/Country/Countries.cpp
+++ b/EU4toV2/Source/EU4World/Country/Countries.cpp
@@ -11,7 +11,7 @@ EU4::Countries::Countries(
 	registerKeyword("REB", commonItems::ignoreItem);
 	registerKeyword("PIR", commonItems::ignoreItem);
 	registerKeyword("NAT", commonItems::ignoreItem);
-	registerRegex("[A-Z]{3}|[A-Z][0-9]{2}", [this, theVersion, ideaEffectMapper, cultureGroupsMapper](const std::string& tag, std::istream& theStream)
+	registerRegex("[A-Z0-9]{3}", [this, theVersion, ideaEffectMapper, cultureGroupsMapper](const std::string& tag, std::istream& theStream)
 		{
 			auto country = std::make_shared<Country>(tag, theVersion, theStream, ideaEffectMapper, cultureGroupsMapper);
 			theCountries.insert(std::make_pair(tag, country));


### PR DESCRIPTION
We weren't catching alpha-alpha-digit, which apparently some mods use.