### PR TITLE
Fix for non-ascii names

### DIFF
--- a/EU4toV2/Source/EU4World/Country/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/Country/EU4Country.cpp
@@ -11,6 +11,7 @@
 #include "EU4Modifier.h"
 #include "EU4ActiveIdeas.h"
 #include <cmath>
+#include "OSCompatibilityLayer.h"
 
 EU4::Country::Country(
 	std::string countryTag,
@@ -24,6 +25,7 @@ EU4::Country::Country(
 		{
 			const commonItems::singleString theName(theStream);
 			name = theName.getString();
+			name = Utils::normalizeUTF8Path(name);
 		});
 	registerKeyword("custom_name", [this](const std::string& unused, std::istream& theStream)
 		{


### PR DESCRIPTION
Vic2 cannot read filenames with non-base-ascii characters in them, so base country names need to conform.