### PR TITLE
Removing Arab culture-cores

### DIFF
--- a/EU4toV2/Data_Files/blankMod/output/events/converterEvents.txt
+++ b/EU4toV2/Data_Files/blankMod/output/events/converterEvents.txt
@@ -2555,36 +2555,37 @@ country_event = {
 		add_accepted_culture = tibetan
 	}
 }
-country_event = { 
+province_event = { 
 	id = 550028
 	title = EVTNAME550028
 	desc = EVTDESC550028
 
 	trigger = { 
-		tag = ALL
-		NOT = { has_global_flag = allahu_akbar }
+		exists = ALL
+		controlled_by = ALL
+		any_pop = {
+			strata = middle
+			OR = { #Islamic
+				pop_majority_religion = sunni
+				pop_majority_religion = zikri
+				pop_majority_religion = yazidi
+				pop_majority_religion = sunni_heresy
+				pop_majority_religion = shiite
+				pop_majority_religion = hurufi
+				pop_majority_religion = druze
+				pop_majority_religion = shiite_heresy
+				pop_majority_religion = ibadi
+				pop_majority_religion = kharijite
+			}
+		}
+		NOT = { is_core = ALL }
 	}
 
-	mean_time_to_happen = { months = 1 }
+	mean_time_to_happen = { months = 0.0001 }
 
 	option = { 
 		name = EVTOPTA550028
-		ARA = {
-			all_core = {
-				remove_core = ARA
-				add_core = ALL
-			}
-		}
-		#Adding cores back to Saudi Arabia
-		NEJ = { all_core = { add_core = ARA } }
-		HDJ = { all_core = { add_core = ARA } }
-		HAL = { all_core = { add_core = ARA } }
-		ARA = { any_owned = { add_core = ARA } }
-		prestige = 10
-		set_global_flag = allahu_akbar
-		ALL = {
-			add_accepted_culture = union
-		}
+		add_core = ALL
 	}
 }
 country_event = { 

--- a/EU4toV2/Data_Files/configurables/unions.txt
+++ b/EU4toV2/Data_Files/configurables/unions.txt
@@ -72,11 +72,11 @@ link = { tag = UBD culture = estonian } #and Estonia
 
 
 #Arab => Arabia
-link = { tag = ARA culture = maghrebi }
-link = { tag = ARA culture = misri } #and Egypt
-link = { tag = ARA culture = mashriqi } #and Iraq
+#link = { tag = ARA culture = maghrebi }
+#link = { tag = ARA culture = misri } #and Egypt
+#link = { tag = ARA culture = mashriqi } #and Iraq
 link = { tag = ARA culture = bedouin }
-link = { tag = ARA culture = berber }
+#link = { tag = ARA culture = berber }
 
 #Persian
 link = { tag = TKS culture = uzbek } #Turkestan


### PR DESCRIPTION
As Vic2 Arabia doesn't have cultural cores lingering around, neither shall we.
Otherwise, Saudi Arabia would feel entitled to conquer everything from Gibraltar to Sudan.
Also fixed the Caliphate to get cores everywhere they control a Mosque.