### PR TITLE
Decentralized HRE

### DIFF
--- a/EU4ToVic2Tests/EU4WorldTests/RelationTests/EU4EmpireTests.cpp
+++ b/EU4ToVic2Tests/EU4WorldTests/RelationTests/EU4EmpireTests.cpp
@@ -17,3 +17,20 @@ TEST(EU4World_Relations_EmpireTests, primitivesCanBeLoaded)
 
 	ASSERT_EQ("HAB", empire.getEmperor());
 }
+
+TEST(EU4World_Relations_EmpireTests, refomsDefaultToBlank)
+{
+	std::stringstream input;
+	const EU4::EU4Empire empire(input);
+
+	ASSERT_TRUE(empire.getHREReforms().empty());
+}
+
+TEST(EU4World_Relations_EmpireTests, reformsCanBeLoaded)
+{
+	std::stringstream input;
+	input << "passed_reform=emperor_geteilte_macht\n";
+	const EU4::EU4Empire empire(input);
+
+	ASSERT_TRUE(empire.getHREReforms().contains("emperor_geteilte_macht"));
+}

--- a/EU4toV2/Data_Files/blankMod/output/decisions/converterUnions.txt
+++ b/EU4toV2/Data_Files/blankMod/output/decisions/converterUnions.txt
@@ -32,6 +32,7 @@ political_decisions = {
 		news_desc_medium = "hre_NEWS_MEDIUM"
 		news_desc_short = "hre_NEWS_SHORT"
 		potential = {
+			capital_scope = { is_core = HRE }
 			OR = {
 				AND = {
 					NOT = { has_global_flag = liberal_revolutions_should_now_fire }

--- a/EU4toV2/Source/EU4World/Relations/EU4Empire.cpp
+++ b/EU4toV2/Source/EU4World/Relations/EU4Empire.cpp
@@ -13,5 +13,9 @@ void EU4::EU4Empire::registerKeywords()
 	registerKeyword("emperor", [this](const std::string& unused, std::istream& theStream) {
 		emperor = commonItems::singleString(theStream).getString();
 	});
+	registerKeyword("passed_reform", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleString reformStr(theStream);
+		reforms.insert(reformStr.getString());
+	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/EU4toV2/Source/EU4World/Relations/EU4Empire.cpp
+++ b/EU4toV2/Source/EU4World/Relations/EU4Empire.cpp
@@ -14,8 +14,7 @@ void EU4::EU4Empire::registerKeywords()
 		emperor = commonItems::singleString(theStream).getString();
 	});
 	registerKeyword("passed_reform", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleString reformStr(theStream);
-		reforms.insert(reformStr.getString());
+		reforms.insert(commonItems::singleString(theStream).getString());
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/EU4toV2/Source/EU4World/Relations/EU4Empire.h
+++ b/EU4toV2/Source/EU4World/Relations/EU4Empire.h
@@ -1,6 +1,7 @@
 #ifndef EU4EMPIRE_H
 #define EU4EMPIRE_H
 #include "Parser.h"
+#include <set>
 
 namespace EU4
 {
@@ -10,11 +11,13 @@ class EU4Empire: commonItems::parser
 	explicit EU4Empire(std::istream& theStream);
 
 	[[nodiscard]] const auto& getEmperor() const { return emperor; }
+	[[nodiscard]] const auto& getHREReforms() const { return reforms; }
 
   private:
 	void registerKeywords();
 
 	std::string emperor;
+	std::set<std::string> reforms;
 };
 } // namespace EU4
 

--- a/EU4toV2/Source/EU4World/World.cpp
+++ b/EU4toV2/Source/EU4World/World.cpp
@@ -193,6 +193,7 @@ void EU4::World::registerKeys(const mappers::IdeaEffectMapper& ideaEffectMapper)
 	registerKeyword("empire", [this](const std::string& unused, std::istream& theStream) {
 		const EU4Empire empireBlock(theStream);
 		holyRomanEmperor = empireBlock.getEmperor();
+		hreReforms = empireBlock.getHREReforms();
 	});
 	// Old style of marking the emperor pre-1.20
 	registerKeyword("emperor", [this](const std::string& unused, std::istream& theStream) {

--- a/EU4toV2/Source/EU4World/World.h
+++ b/EU4toV2/Source/EU4World/World.h
@@ -36,6 +36,7 @@ class World: commonItems::parser
 	[[nodiscard]] const auto& getProvinces() const { return provinces->getAllProvinces(); }
 	[[nodiscard]] const auto& getHistoricalData() const { return historicalData; }
 	[[nodiscard]] const auto& getNativeCultures() const { return nativeCultures; }
+	[[nodiscard]] const auto& getHREReforms() const { return hreReforms; }
 
   private:
 	void registerKeys(const mappers::IdeaEffectMapper& ideaEffectMapper);
@@ -76,6 +77,7 @@ class World: commonItems::parser
 	saveData saveGame;
 
 	std::string holyRomanEmperor;
+	std::set<std::string> hreReforms;
 	std::string celestialEmperor;
 	std::unique_ptr<Regions> regions;
 	std::unique_ptr<Provinces> provinces;

--- a/EU4toV2/Source/EU4World/World.h
+++ b/EU4toV2/Source/EU4World/World.h
@@ -37,6 +37,7 @@ class World: commonItems::parser
 	[[nodiscard]] const auto& getHistoricalData() const { return historicalData; }
 	[[nodiscard]] const auto& getNativeCultures() const { return nativeCultures; }
 	[[nodiscard]] const auto& getHREReforms() const { return hreReforms; }
+	[[nodiscard]] bool decentralizedHRE() const { return hreReforms.contains("emperor_reichskrieg"); }
 
   private:
 	void registerKeys(const mappers::IdeaEffectMapper& ideaEffectMapper);

--- a/EU4toV2/Source/Mappers/CultureGroups/CultureGroup.h
+++ b/EU4toV2/Source/Mappers/CultureGroups/CultureGroup.h
@@ -18,7 +18,7 @@ class CultureGroup: commonItems::parser
 
 	void addNeoCulture(const std::string& theName, const std::shared_ptr<Culture>& culture, const std::string& oldCulture);
 	void mergeCulture(const std::string& theName, const std::shared_ptr<Culture>& culture);
-	void setUnionTag(const std::string& tag) { culturalUnionTag = tag; }
+	void clearUnionTag() { culturalUnionTag.clear(); }
 
 	friend std::ostream& operator<<(std::ostream& output, const CultureGroup& cultureGroup);
 

--- a/EU4toV2/Source/Mappers/CultureGroups/CultureGroup.h
+++ b/EU4toV2/Source/Mappers/CultureGroups/CultureGroup.h
@@ -18,6 +18,7 @@ class CultureGroup: commonItems::parser
 
 	void addNeoCulture(const std::string& theName, const std::shared_ptr<Culture>& culture, const std::string& oldCulture);
 	void mergeCulture(const std::string& theName, const std::shared_ptr<Culture>& culture);
+	void setUnionTag(const std::string& tag) { culturalUnionTag = tag; }
 
 	friend std::ostream& operator<<(std::ostream& output, const CultureGroup& cultureGroup);
 

--- a/EU4toV2/Source/V2World/Country/Country.h
+++ b/EU4toV2/Source/V2World/Country/Country.h
@@ -138,6 +138,8 @@ class Country
 	[[nodiscard]] const auto& getEU4PrimaryCulture() const { return details.eu4PrimaryCulture; }
 	[[nodiscard]] const auto& getAcceptedCultures() const { return details.acceptedCultures; }
 	[[nodiscard]] const auto& getEU4AcceptedCultures() const { return details.eu4acceptedCultures; }
+	[[nodiscard]] bool isEmperorHRE() const { return details.holyRomanEmperor; }
+	[[nodiscard]] bool isMemberHRE() const { return details.inHRE; }
 
 	friend std::ostream& operator<<(std::ostream& output, const Country& country);
 	void outputCommons(std::ostream& output);

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
@@ -1,6 +1,5 @@
 #include "Diplomacy.h"
 #include "../../Configuration.h"
-#include "World.h"
 #include "../../EU4World/Country/EU4Country.h"
 #include "../Country/Country.h"
 #include "Log.h"
@@ -220,7 +219,7 @@ void V2::Diplomacy::convertRelationsToInfluence(const std::map<std::string, std:
 }
 
 void V2::Diplomacy::sphereHRE(bool hreDecentralized,
-	std::shared_ptr<Country> emperor,
+	const std::shared_ptr<Country>& emperor,
 	const std::map<std::string, std::shared_ptr<Country>>& countries
 ){
 	if (!hreDecentralized || !emperor)

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
@@ -1,5 +1,6 @@
 #include "Diplomacy.h"
 #include "../../Configuration.h"
+#include "../../EU4World/World.h"
 #include "../../EU4World/Country/EU4Country.h"
 #include "../Country/Country.h"
 #include "Log.h"
@@ -214,6 +215,35 @@ void V2::Diplomacy::convertRelationsToInfluence(const std::map<std::string, std:
 				}
 				relation.second.setInfluence(newInfluence);
 			}
+		}
+	}
+}
+
+void V2::Diplomacy::sphereHRE(const EU4::World& sourceWorld, std::map<std::string, std::shared_ptr<Country>>& countries)
+{
+	if (const auto& hreReforms = sourceWorld.getHREReforms();
+		 std::find(hreReforms.begin(), hreReforms.end(), "emperor_reichskrieg") == hreReforms.end())
+	{
+		return;
+	}
+	else
+	{
+		Log(LogLevel::Info) << "\tSphereing HRE";
+
+		const auto& emperorItr = std::find_if(countries.begin(), countries.end(),
+			[](const std::pair<std::string, std::shared_ptr<Country>>& country)
+			{
+				return country.second->isEmperorHRE();
+			});
+		const auto& emperor = emperorItr->second;
+
+		for (const auto& country: countries)
+		{
+			if (!country.second->isMemberHRE())
+				continue;
+			auto& relation = emperor->getRelation(country.second->getTag());
+			relation.setLevel(5);
+			relation.setAccess(true);
 		}
 	}
 }

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.cpp
@@ -1,6 +1,6 @@
 #include "Diplomacy.h"
 #include "../../Configuration.h"
-#include "../../EU4World/World.h"
+#include "World.h"
 #include "../../EU4World/Country/EU4Country.h"
 #include "../Country/Country.h"
 #include "Log.h"
@@ -219,32 +219,21 @@ void V2::Diplomacy::convertRelationsToInfluence(const std::map<std::string, std:
 	}
 }
 
-void V2::Diplomacy::sphereHRE(const EU4::World& sourceWorld, std::map<std::string, std::shared_ptr<Country>>& countries)
-{
-	if (const auto& hreReforms = sourceWorld.getHREReforms();
-		 std::find(hreReforms.begin(), hreReforms.end(), "emperor_reichskrieg") == hreReforms.end())
-	{
+void V2::Diplomacy::sphereHRE(bool hreDecentralized,
+	std::shared_ptr<Country> emperor,
+	const std::map<std::string, std::shared_ptr<Country>>& countries
+){
+	if (!hreDecentralized || !emperor)
 		return;
-	}
-	else
+
+	Log(LogLevel::Info) << "\tSphereing HRE";
+	for (const auto& country: countries)
 	{
-		Log(LogLevel::Info) << "\tSphereing HRE";
-
-		const auto& emperorItr = std::find_if(countries.begin(), countries.end(),
-			[](const std::pair<std::string, std::shared_ptr<Country>>& country)
-			{
-				return country.second->isEmperorHRE();
-			});
-		const auto& emperor = emperorItr->second;
-
-		for (const auto& country: countries)
-		{
-			if (!country.second->isMemberHRE())
-				continue;
-			auto& relation = emperor->getRelation(country.second->getTag());
-			relation.setLevel(5);
-			relation.setAccess(true);
-		}
+		if (!country.second->isMemberHRE() || country.second->isEmperorHRE())
+			continue;
+		auto& relation = emperor->getRelation(country.second->getTag());
+		relation.setLevel(5);
+		relation.setAccess(true);
 	}
 }
 

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.h
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.h
@@ -20,7 +20,9 @@ class Diplomacy
 	void convertDiplomacy(std::vector<EU4::EU4Agreement> agreements,
 		 const mappers::CountryMappings& countryMapper,
 		 std::map<std::string, std::shared_ptr<Country>>& countries);
-	void sphereHRE(const EU4::World& sourceWorld, std::map<std::string, std::shared_ptr<Country>>& countries);
+	void sphereHRE(bool hreDecentralized,
+		std::shared_ptr<Country> emperor,
+		const std::map<std::string, std::shared_ptr<Country>>& countries);
 
   private:
 	std::vector<Agreement> agreements;

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.h
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.h
@@ -3,7 +3,6 @@
 
 #include "../../Mappers/AgreementMapper/AgreementMapper.h"
 #include "../../Mappers/CountryMappings/CountryMappings.h"
-#include "../EU4toV2/Source/EU4World/World.h"
 #include "../EU4toV2/Source/EU4World/Diplomacy/EU4Agreement.h"
 #include "Agreement.h"
 #include <vector>
@@ -21,7 +20,7 @@ class Diplomacy
 		 const mappers::CountryMappings& countryMapper,
 		 std::map<std::string, std::shared_ptr<Country>>& countries);
 	void sphereHRE(bool hreDecentralized,
-		std::shared_ptr<Country> emperor,
+		const std::shared_ptr<Country>& emperor,
 		const std::map<std::string, std::shared_ptr<Country>>& countries);
 
   private:

--- a/EU4toV2/Source/V2World/Diplomacy/Diplomacy.h
+++ b/EU4toV2/Source/V2World/Diplomacy/Diplomacy.h
@@ -3,6 +3,7 @@
 
 #include "../../Mappers/AgreementMapper/AgreementMapper.h"
 #include "../../Mappers/CountryMappings/CountryMappings.h"
+#include "../EU4toV2/Source/EU4World/World.h"
 #include "../EU4toV2/Source/EU4World/Diplomacy/EU4Agreement.h"
 #include "Agreement.h"
 #include <vector>
@@ -19,6 +20,7 @@ class Diplomacy
 	void convertDiplomacy(std::vector<EU4::EU4Agreement> agreements,
 		 const mappers::CountryMappings& countryMapper,
 		 std::map<std::string, std::shared_ptr<Country>>& countries);
+	void sphereHRE(const EU4::World& sourceWorld, std::map<std::string, std::shared_ptr<Country>>& countries);
 
   private:
 	std::vector<Agreement> agreements;

--- a/EU4toV2/Source/V2World/Output/outProvince.cpp
+++ b/EU4toV2/Source/V2World/Output/outProvince.cpp
@@ -11,10 +11,6 @@ std::ostream& V2::operator<<(std::ostream& output, const Province& province)
 	{
 		output << "add_core=" << core << "\n";
 	}
-	if (province.inHRE)
-	{
-		output << "add_core=HRE\n";
-	}
 	if (!province.details.rgoType.empty())
 	{
 		output << "trade_goods = " << province.details.rgoType << "\n";

--- a/EU4toV2/Source/V2World/Province/Province.cpp
+++ b/EU4toV2/Source/V2World/Province/Province.cpp
@@ -1,6 +1,6 @@
 #include "Province.h"
 #include "../../Configuration.h"
-#include "../../EU4World/World.h"
+#include "World.h"
 #include "../../EU4World/Regions/Regions.h"
 #include "../../Mappers/CountryMappings/CountryMappings.h"
 #include "../../Mappers/CultureMapper/CultureMapper.h"
@@ -99,8 +99,7 @@ void V2::Province::addCore(const std::string& newCore)
 	}
 }
 
-void V2::Province::convertFromOldProvince(const EU4::World& sourceWorld,
-	 const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
+void V2::Province::convertFromOldProvince(const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
 	 const std::map<std::string, std::shared_ptr<EU4::Country>>& theEU4Countries,
 	 const EU4::Regions& eu4Regions,
 	 mappers::CultureMapper& cultureMapper,
@@ -108,7 +107,8 @@ void V2::Province::convertFromOldProvince(const EU4::World& sourceWorld,
 	 const mappers::Continents& continentsMapper,
 	 const mappers::ReligionMapper& religionMapper,
 	 const mappers::CountryMappings& countryMapper,
-	 const mappers::ProvinceMapper& provinceMapper)
+	 const mappers::ProvinceMapper& provinceMapper,
+	 bool hreDecentralized)
 {
 	// Drop vanilla cores
 	details.cores.clear();
@@ -126,8 +126,7 @@ void V2::Province::convertFromOldProvince(const EU4::World& sourceWorld,
 		if (oldProvince->inHre())
 		{
 			inHRE = true;
-			if (const auto& hreReforms = sourceWorld.getHREReforms();
-				 std::find(hreReforms.begin(), hreReforms.end(), "emperor_reichskrieg") == hreReforms.end())
+			if (!hreDecentralized)
 				addCore("HRE");
 		}
 	}

--- a/EU4toV2/Source/V2World/Province/Province.cpp
+++ b/EU4toV2/Source/V2World/Province/Province.cpp
@@ -1,5 +1,6 @@
 #include "Province.h"
 #include "../../Configuration.h"
+#include "../../EU4World/World.h"
 #include "../../EU4World/Regions/Regions.h"
 #include "../../Mappers/CountryMappings/CountryMappings.h"
 #include "../../Mappers/CultureMapper/CultureMapper.h"
@@ -98,7 +99,8 @@ void V2::Province::addCore(const std::string& newCore)
 	}
 }
 
-void V2::Province::convertFromOldProvince(const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
+void V2::Province::convertFromOldProvince(const EU4::World& sourceWorld,
+	 const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
 	 const std::map<std::string, std::shared_ptr<EU4::Country>>& theEU4Countries,
 	 const EU4::Regions& eu4Regions,
 	 mappers::CultureMapper& cultureMapper,
@@ -120,9 +122,16 @@ void V2::Province::convertFromOldProvince(const std::vector<std::shared_ptr<EU4:
 
 	// Single HRE province is enough
 	for (const auto& oldProvince: provinceSources)
+	{
 		if (oldProvince->inHre())
+		{
 			inHRE = true;
-
+			if (const auto& hreReforms = sourceWorld.getHREReforms();
+				 std::find(hreReforms.begin(), hreReforms.end(), "emperor_reichskrieg") == hreReforms.end())
+				addCore("HRE");
+		}
+	}
+	
 	territorialCore = false; // A single territorial core will be sufficient to trip this.
 	for (const auto& oldProvince: provinceSources)
 	{

--- a/EU4toV2/Source/V2World/Province/Province.cpp
+++ b/EU4toV2/Source/V2World/Province/Province.cpp
@@ -1,6 +1,5 @@
 #include "Province.h"
 #include "../../Configuration.h"
-#include "World.h"
 #include "../../EU4World/Regions/Regions.h"
 #include "../../Mappers/CountryMappings/CountryMappings.h"
 #include "../../Mappers/CultureMapper/CultureMapper.h"

--- a/EU4toV2/Source/V2World/Province/Province.h
+++ b/EU4toV2/Source/V2World/Province/Province.h
@@ -1,7 +1,7 @@
 #ifndef PROVINCE_H
 #define PROVINCE_H
 
-#include "../../EU4World/World.h"
+#include "World.h"
 #include "../../EU4World/Country/EU4Country.h"
 #include "../../EU4World/Provinces/EU4Province.h"
 #include "../../Mappers/Geography/ClimateMapper.h"
@@ -105,8 +105,7 @@ class Province
 	std::shared_ptr<Pop> getSoldierPopForArmy(bool force = false);
 
 	void sterilizeProvince();
-	void convertFromOldProvince(const EU4::World& sourceWorld,
-		 const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
+	void convertFromOldProvince(const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
 		 const std::map<std::string, std::shared_ptr<EU4::Country>>& theEU4Countries,
 		 const EU4::Regions& eu4Regions,
 		 mappers::CultureMapper& cultureMapper,
@@ -114,7 +113,8 @@ class Province
 		 const mappers::Continents& continentsMapper,
 		 const mappers::ReligionMapper& religionMapper,
 		 const mappers::CountryMappings& countryMapper,
-		 const mappers::ProvinceMapper& provinceMapper);
+		 const mappers::ProvinceMapper& provinceMapper,
+		 bool hreDecentralized);
 	void doCreatePops(double popWeightRatio, Country* _owner, CIV_ALGORITHM popConversionAlgorithm, const mappers::ProvinceMapper& provinceMapper);
 
 	friend std::ostream& operator<<(std::ostream& output, const Province& province);

--- a/EU4toV2/Source/V2World/Province/Province.h
+++ b/EU4toV2/Source/V2World/Province/Province.h
@@ -1,7 +1,6 @@
 #ifndef PROVINCE_H
 #define PROVINCE_H
 
-#include "World.h"
 #include "../../EU4World/Country/EU4Country.h"
 #include "../../EU4World/Provinces/EU4Province.h"
 #include "../../Mappers/Geography/ClimateMapper.h"

--- a/EU4toV2/Source/V2World/Province/Province.h
+++ b/EU4toV2/Source/V2World/Province/Province.h
@@ -1,6 +1,7 @@
 #ifndef PROVINCE_H
 #define PROVINCE_H
 
+#include "../../EU4World/World.h"
 #include "../../EU4World/Country/EU4Country.h"
 #include "../../EU4World/Provinces/EU4Province.h"
 #include "../../Mappers/Geography/ClimateMapper.h"
@@ -104,7 +105,8 @@ class Province
 	std::shared_ptr<Pop> getSoldierPopForArmy(bool force = false);
 
 	void sterilizeProvince();
-	void convertFromOldProvince(const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
+	void convertFromOldProvince(const EU4::World& sourceWorld,
+		 const std::vector<std::shared_ptr<EU4::Province>>& provinceSources,
 		 const std::map<std::string, std::shared_ptr<EU4::Country>>& theEU4Countries,
 		 const EU4::Regions& eu4Regions,
 		 mappers::CultureMapper& cultureMapper,

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -73,6 +73,7 @@ V2::World::World(const EU4::World& sourceWorld,
 
 	LOG(LogLevel::Info) << "-> Converting Diplomacy";
 	diplomacy.convertDiplomacy(sourceWorld.getDiplomaticAgreements(), countryMapper, countries);
+	diplomacy.sphereHRE(sourceWorld, countries);
 	Log(LogLevel::Progress) << "55 %";
 
 	LOG(LogLevel::Info) << "-> Setting Up States";
@@ -112,7 +113,8 @@ V2::World::World(const EU4::World& sourceWorld,
 	Log(LogLevel::Progress) << "65 %";
 
 	LOG(LogLevel::Info) << "-> Merging Nations";
-	addUnions();
+	addUnions(sourceWorld);
+	decentralizeHRE(sourceWorld);
 
 	Log(LogLevel::Info) << "-> Invoking the Undead";
 	updateDeadNations();
@@ -979,7 +981,8 @@ void V2::World::convertProvinces(const EU4::World& sourceWorld, const mappers::T
 			}
 		}
 
-		province.second->convertFromOldProvince(filteredSources,
+		province.second->convertFromOldProvince(sourceWorld,
+			 filteredSources,
 			 sourceWorld.getCountries(),
 			 sourceWorld.getRegions(),
 			 cultureMapper,
@@ -1364,7 +1367,7 @@ void V2::World::setupPops(const EU4::World& sourceWorld)
 	LOG(LogLevel::Info) << "New total world population: " << newTotalPopulation;
 }
 
-void V2::World::addUnions()
+void V2::World::addUnions(const EU4::World& sourceWorld)
 {
 	if (theConfiguration.getCoreHandling() == Configuration::COREHANDLES::DropAll)
 		return;
@@ -1380,6 +1383,15 @@ void V2::World::addUnions()
 			{
 				auto unionCores = culturalUnionMapper->getCoresForCulture(culture);
 				auto nationalCores = culturalNationalitiesMapper->getCoresForCulture(culture);
+
+				// Skip Germany if the Empire was decentralized
+				if (const auto& gerItr = std::find(unionCores.begin(), unionCores.end(), "GER");
+					sourceWorld.getHREReforms().count("emperor_reichskrieg")
+					&& gerItr != unionCores.end())
+				{
+					unionCores.erase(gerItr);
+				}
+
 				switch (theConfiguration.getCoreHandling())
 				{
 					case Configuration::COREHANDLES::DropNational:
@@ -1402,6 +1414,12 @@ void V2::World::addUnions()
 			}
 		}
 	}
+}
+
+void V2::World::decentralizeHRE(const EU4::World& sourceWorld)
+{
+	if (sourceWorld.getHREReforms().count("emperor_reichskrieg"))
+		cultureGroupsMapper.getGroupForCulture("german")->setUnionTag("");
 }
 
 

--- a/EU4toV2/Source/V2World/V2World.cpp
+++ b/EU4toV2/Source/V2World/V2World.cpp
@@ -113,8 +113,8 @@ V2::World::World(const EU4::World& sourceWorld,
 	Log(LogLevel::Progress) << "65 %";
 
 	LOG(LogLevel::Info) << "-> Merging Nations";
-	addUnions(sourceWorld);
-	decentralizeHRE(sourceWorld);
+	addUnions(sourceWorld.decentralizedHRE());
+	decentralizeHRE(sourceWorld.decentralizedHRE());
 
 	Log(LogLevel::Info) << "-> Invoking the Undead";
 	updateDeadNations();
@@ -981,8 +981,7 @@ void V2::World::convertProvinces(const EU4::World& sourceWorld, const mappers::T
 			}
 		}
 
-		province.second->convertFromOldProvince(sourceWorld,
-			 filteredSources,
+		province.second->convertFromOldProvince(filteredSources,
 			 sourceWorld.getCountries(),
 			 sourceWorld.getRegions(),
 			 cultureMapper,
@@ -990,7 +989,8 @@ void V2::World::convertProvinces(const EU4::World& sourceWorld, const mappers::T
 			 continentsMapper,
 			 religionMapper,
 			 countryMapper,
-			 provinceMapper);
+			 provinceMapper,
+			 sourceWorld.decentralizedHRE());
 	}
 }
 
@@ -1367,7 +1367,7 @@ void V2::World::setupPops(const EU4::World& sourceWorld)
 	LOG(LogLevel::Info) << "New total world population: " << newTotalPopulation;
 }
 
-void V2::World::addUnions(const EU4::World& sourceWorld)
+void V2::World::addUnions(bool hreDecentralized)
 {
 	if (theConfiguration.getCoreHandling() == Configuration::COREHANDLES::DropAll)
 		return;
@@ -1386,8 +1386,7 @@ void V2::World::addUnions(const EU4::World& sourceWorld)
 
 				// Skip Germany if the Empire was decentralized
 				if (const auto& gerItr = std::find(unionCores.begin(), unionCores.end(), "GER");
-					sourceWorld.getHREReforms().count("emperor_reichskrieg")
-					&& gerItr != unionCores.end())
+					hreDecentralized && gerItr != unionCores.end())
 				{
 					unionCores.erase(gerItr);
 				}
@@ -1416,10 +1415,10 @@ void V2::World::addUnions(const EU4::World& sourceWorld)
 	}
 }
 
-void V2::World::decentralizeHRE(const EU4::World& sourceWorld)
+void V2::World::decentralizeHRE(bool hreDecentralized)
 {
-	if (sourceWorld.getHREReforms().count("emperor_reichskrieg"))
-		cultureGroupsMapper.getGroupForCulture("german")->setUnionTag("");
+	if (hreDecentralized)
+		cultureGroupsMapper.getGroupForCulture("german")->clearUnionTag();
 }
 
 

--- a/EU4toV2/Source/V2World/V2World.h
+++ b/EU4toV2/Source/V2World/V2World.h
@@ -101,7 +101,8 @@ class World
 	void convertTechs(const EU4::World& sourceWorld);
 	void allocateFactories(const EU4::World& sourceWorld);
 	void setupPops(const EU4::World& sourceWorld);
-	void addUnions();
+	void addUnions(const EU4::World& sourceWorld);
+	void decentralizeHRE(const EU4::World& sourceWorld);
 	void convertArmies();
 	void output(const mappers::VersionParser& versionParser) const;
 	void createModFile() const;

--- a/EU4toV2/Source/V2World/V2World.h
+++ b/EU4toV2/Source/V2World/V2World.h
@@ -75,6 +75,7 @@ class World
 	[[nodiscard]] std::shared_ptr<Province> getProvince(int provID) const;
 	[[nodiscard]] std::shared_ptr<Country> getCountry(const std::string& tag) const;
 	[[nodiscard]] unsigned int countCivilizedNations() const;
+	[[nodiscard]] std::shared_ptr<Country> getHreEmperor() const;
 
 	static std::optional<std::string> determineProvinceControllership(const std::set<int>& eu4ProvinceNumbers, const EU4::World& sourceWorld);
 	std::shared_ptr<Country> createOrLocateCountry(const std::string& V2Tag, const EU4::Country& sourceCountry);
@@ -101,9 +102,8 @@ class World
 	void convertTechs(const EU4::World& sourceWorld);
 	void allocateFactories(const EU4::World& sourceWorld);
 	void setupPops(const EU4::World& sourceWorld);
-	void addUnions(bool hreDecentralized, const std::string& emperorCulture);
-	void decentralizeHRE(bool hreDecentralized, const std::string& emperorCulture);
-	std::shared_ptr<Country> findEmperorHRE();
+	void addUnions(bool hreDecentralized, const std::shared_ptr<Country>& emperor);
+	void decentralizeHRE(bool hreDecentralized, const std::shared_ptr<Country>& emperor);
 	void convertArmies();
 	void output(const mappers::VersionParser& versionParser) const;
 	void createModFile() const;

--- a/EU4toV2/Source/V2World/V2World.h
+++ b/EU4toV2/Source/V2World/V2World.h
@@ -101,8 +101,8 @@ class World
 	void convertTechs(const EU4::World& sourceWorld);
 	void allocateFactories(const EU4::World& sourceWorld);
 	void setupPops(const EU4::World& sourceWorld);
-	void addUnions(const EU4::World& sourceWorld);
-	void decentralizeHRE(const EU4::World& sourceWorld);
+	void addUnions(bool hreDecentralized);
+	void decentralizeHRE(bool hreDecentralized);
 	void convertArmies();
 	void output(const mappers::VersionParser& versionParser) const;
 	void createModFile() const;

--- a/EU4toV2/Source/V2World/V2World.h
+++ b/EU4toV2/Source/V2World/V2World.h
@@ -101,8 +101,9 @@ class World
 	void convertTechs(const EU4::World& sourceWorld);
 	void allocateFactories(const EU4::World& sourceWorld);
 	void setupPops(const EU4::World& sourceWorld);
-	void addUnions(bool hreDecentralized);
-	void decentralizeHRE(bool hreDecentralized);
+	void addUnions(bool hreDecentralized, const std::string& emperorCulture);
+	void decentralizeHRE(bool hreDecentralized, const std::string& emperorCulture);
+	std::shared_ptr<Country> findEmperorHRE();
 	void convertArmies();
 	void output(const mappers::VersionParser& versionParser) const;
 	void createModFile() const;


### PR DESCRIPTION
Removes Germany and Holy Roman Empire (country) in case the HRE enacted all decentralization reforms

- remove German cores from all provinces - disables forming Germany
- remove HRE cores from all provinces - disables HRE Nationalists
- disable centralize_hre decision when no HRE core in capital - disables forming HRE
- remove GER as a cultural union for germanic culture group - disables German Pan-Nationalists
- sphere HRE members to Emperor and grant military access through their territory