### PR TITLE
HPM coral_island patch

### DIFF
--- a/EU4toV2/Source/Mappers/ProvinceDetails/ProvinceDetailsMapper.cpp
+++ b/EU4toV2/Source/Mappers/ProvinceDetails/ProvinceDetailsMapper.cpp
@@ -34,7 +34,9 @@ void mappers::ProvinceDetailsMapper::registerKeys()
 		provinceDetails.lifeRating = commonItems::singleInt(theStream).getInt();
 	});
 	registerKeyword("terrain", [this](const std::string& unused, std::istream& theStream) {
-		provinceDetails.terrain = commonItems::singleString(theStream).getString();
+		const auto& terrainStr = commonItems::singleString(theStream).getString();
+		if (terrainStr != "coral_island")
+			provinceDetails.terrain = terrainStr;
 	});
 	registerKeyword("colonial", [this](const std::string& unused, std::istream& theStream) {
 		provinceDetails.colonial = commonItems::singleInt(theStream).getInt();


### PR DESCRIPTION
For some reason the game gets stuck at "Adapting History" when `coral_island` terrain is assigned to some Pacific islands. Until it's solved, coral_island is removed from province history.