### PR TITLE
Updates to Apply to US Statehood

### DIFF
--- a/EU4toV2/Data_Files/blankMod/output/decisions/ACW.txt
+++ b/EU4toV2/Data_Files/blankMod/output/decisions/ACW.txt
@@ -4,6 +4,7 @@ political_decisions = {
 		potential = {	
 			exists = USA
 			USA = { government = democracy }
+			is_culture_group = USA
 			OR = {
 				tag = TEX
 				tag = DES
@@ -12,15 +13,12 @@ political_decisions = {
 				tag = LOU
 				tag = UIL # Illinois
 				tag = UNB # Nebraska
-				AND = {
-					tag = UNM # New Mexico
-					OR = {
-						primary_culture = texan
-						primary_culture = dixie
-					}
-				}
+				tag = UNM # New Mexico
 				tag = UNY # New York
 				tag = UOR # Oregon
+				capital_scope = { # Any other minors with dynamic tags, e.g. Vermont
+					is_core = USA
+				}
 			}
 			OR = {
 				is_vassal = no


### PR DESCRIPTION
Restricts applying to US statehood only to US states in the same culture group as the in-world USA. E.g. a French Texas would join a French USA, but an English Texas would not. This way the US won't just diplomatically grab the rest of the modern US while having no historical in-world claim to it.