### PR TITLE
Import Vanilla province localization for hybridization

### DIFF
--- a/EU4toV2/Source/Configuration.cpp
+++ b/EU4toV2/Source/Configuration.cpp
@@ -110,6 +110,7 @@ void Configuration::instantiate(std::istream& theStream,
 	{
 		if (!DoesFolderExist(Vic2Path + "/mod/HPM"))
 			throw std::runtime_error(Vic2Path + "/mod/HPM does not exist!");
+		VanillaVic2Path = Vic2Path;	// necessary for importing province localisations
 		Vic2Path += "/mod/HPM";
 	}
 	Log(LogLevel::Progress) << "3 %";

--- a/EU4toV2/Source/Configuration.cpp
+++ b/EU4toV2/Source/Configuration.cpp
@@ -110,7 +110,7 @@ void Configuration::instantiate(std::istream& theStream,
 	{
 		if (!DoesFolderExist(Vic2Path + "/mod/HPM"))
 			throw std::runtime_error(Vic2Path + "/mod/HPM does not exist!");
-		VanillaVic2Path = Vic2Path;	// necessary for importing province localisations
+		VanillaVic2Path = Vic2Path; // necessary for importing province localisations
 		Vic2Path += "/mod/HPM";
 	}
 	Log(LogLevel::Progress) << "3 %";

--- a/EU4toV2/Source/Configuration.h
+++ b/EU4toV2/Source/Configuration.h
@@ -101,6 +101,7 @@ class Configuration: commonItems::parser
 	[[nodiscard]] const auto& getEU4Path() const { return EU4Path; }
 	[[nodiscard]] const auto& getEU4DocumentsPath() const { return EU4DocumentsPath; }
 	[[nodiscard]] const auto& getVic2Path() const { return Vic2Path; }
+	[[nodiscard]] const auto& getVanillaVic2Path() const { return VanillaVic2Path; }
 	[[nodiscard]] const auto& getResetProvinces() const { return resetProvinces; }
 	[[nodiscard]] const auto& getEU4Version() const { return version; }
 	[[nodiscard]] const auto& getFirstEU4Date() const { return firstEU4Date; }
@@ -123,6 +124,7 @@ class Configuration: commonItems::parser
 	std::string EU4Path;
 	std::string EU4DocumentsPath;
 	std::string Vic2Path;
+	std::string VanillaVic2Path;
 	std::string resetProvinces = "no";
 	double MaxLiteracy = 1.0;
 	LIBERTYDESIRE libertyThreshold = LIBERTYDESIRE::Loyal;

--- a/EU4toV2/Source/V2World/Province/ProvinceNameParser.cpp
+++ b/EU4toV2/Source/V2World/Province/ProvinceNameParser.cpp
@@ -11,9 +11,17 @@ V2::ProvinceNameParser::ProvinceNameParser()
 	{
 		importProvinceLocalizations("./blankMod/output/localisation/text.csv");
 	}
-	else
+	const auto& locFolder = theConfiguration.getVic2Path() + "/localisation";
+	if (commonItems::DoesFolderExist(locFolder))
 	{
-		importProvinceLocalizations(theConfiguration.getVic2Path() + "/localisation/text.csv");
+		for (const auto& locFile: commonItems::GetAllFilesInFolderRecursive(locFolder))
+		{
+			importProvinceLocalizations(locFolder + "/" + locFile);
+		}
+	}
+	if (theConfiguration.isHpmEnabled())
+	{
+		importProvinceLocalizations(theConfiguration.getVanillaVic2Path() + "/localisation/text.csv");
 	}
 }
 


### PR DESCRIPTION
Used for naming regiments. Importing HPM province localization isn't enough, because the mod makes only localizations for provinces it renames, the rest is loaded from Vanilla.