### PR TITLE
Fix HRE core removal event

### DIFF
--- a/EU4toV2/Data_Files/blankMod/output/events/shattered_hre.txt
+++ b/EU4toV2/Data_Files/blankMod/output/events/shattered_hre.txt
@@ -29,7 +29,7 @@ country_event = {
 	option = { 
 		name = EVTOPTA250002
 		clr_country_flag = emperor_hre 
-		any_province = { remove_core = HLR }
+		HLR = { all_core = { remove_core = HLR } }
 	}
 }
 


### PR DESCRIPTION
Lack of any_province scope in Vic2 must be the biggest oversight in any Paradox game