### PR TITLE
Cleanup

### DIFF
--- a/EU4ToVic2Tests/MapperTests/VNColonialMapper/VNColonialMappingTests.cpp
+++ b/EU4ToVic2Tests/MapperTests/VNColonialMapper/VNColonialMappingTests.cpp
@@ -9,6 +9,7 @@ TEST(Mappers_VNColonialMappingTests, MappingDefaultsToDefaults)
 	const mappers::VNColonialMapping theMapping(input);
 
 	EXPECT_TRUE(theMapping.getName().empty());
+	EXPECT_TRUE(theMapping.getDecolonizeBlocker().empty());
 	EXPECT_EQ(0, theMapping.getKeyProvince());
 	EXPECT_TRUE(theMapping.getProvinces().empty());
 }
@@ -16,10 +17,11 @@ TEST(Mappers_VNColonialMappingTests, MappingDefaultsToDefaults)
 TEST(Mappers_VNColonialMappingTests, MappingCanBeLoaded)
 {
 	std::stringstream input;
-	input << R"(name = "British Pacifics" key = 290 provinces = { 2524 2508 })";
+	input << R"(name = "British Pacifics" key = 290 provinces = { 2524 2508 } decolonize = RUS )";
 	const mappers::VNColonialMapping theMapping(input);
 
 	EXPECT_EQ("British Pacifics", theMapping.getName());
+	EXPECT_EQ("RUS", theMapping.getDecolonizeBlocker());
 	EXPECT_EQ(290, theMapping.getKeyProvince());
 	EXPECT_THAT(theMapping.getProvinces(), ElementsAre(2524, 2508));
 }

--- a/EU4toV2/Data_Files/configurables/culture_definitions.txt
+++ b/EU4toV2/Data_Files/configurables/culture_definitions.txt
@@ -2730,44 +2730,6 @@ polish_culture_group = {
 		last_names = { Obroditen Gryfita "z Liubic" Swieca Grzymala Jastrzebiec Lodzia Lubicz Nalecz Gniewosz "z Roztoki" "ze Slupska" }
 		radicalism = 10
 	}
-	lithuanian = { 
-		hpm = no
-		color = {17 162 48}
-
-		first_names = { Adolfas Aleksandras Algirdas Andrius Antanas Arturas Arunas Augustinas Balys Boris
-		Bronislovas Danielius Darius Gediminas Henrikas Jonas Jonusas Juozas Juras Jurgis
-		Justas Kazimieras Kazys Kipras Konstantinas Lukas Marijus Markas Mikalojus Mindaugas
-		Motejus Mykolas Paulius Petras Povilas Ramunas Ringaudas Rolandas Simonas Stasys
-		Steponas Valdas Valdemaras Viktoras Vilhelmas Visvaldas Vladimiras Vygantas Vytautas Žydrunas
-		}
-
-		last_names = { Adamkus Almenas Avizienis Baltrušaitis Brazauskas Basanavicius Birutis Brazdžiunas Buga Ciurlionis
-		Danauskas Daukantas Dobkevicius Dubeneckis Dvarionas Galdikas Grinius Griškevicius Ivanauskas Jablonskis
-		Jucys Krupavicius Landsbergis Lozoraitis Merkys Paksas Paleckis Paulauskas Petrauskas Piskarkas
-		Požela Radvila Šabaniauskas Schatz Simonavicius Širvydas Šleževicius Semtona Snieckus Stauaitis
-		Straižys Stulginkis Švedas Terleckas Urbšys Vagnorius Valeška Voldemaras Žemaitis Zuokas
-		}
-	}
-	pruthenian = { 
-		hpm = no
-		color = { 126 214 143 }
-
-		first_names = { 
-			Algirdas Antanas Antavas Aras Arunas Azuolas Budrys Bukantas Butavas Butigeidis Butvydas 
-			Daugvilas Daumantas Dausprungas Dravenis Erdenis Erdvilas Gedigaudas
-			Gediminas Gedivilas Gintaras Gintautas Girdenis Irmantas Jaunutis Jogaila Jovirdas Kantibutas 
-			Karijotas Kesgaila Kestutis Korigaila Korybutas
-			Lasukas Lingvenis Liudas Lubartas Lutuveras Merkelis Mindaugas Minigaila Mantvydas Movkoldas 
-			Narimantas Povilas Pukuveras Rimantas 
-			Rimgaila Rimvydas Ringaudas Sarunas Skirgaila Songaila Svarnas Svitrigaila Tarvydas Tovtivilas 
-			Traidenis Treniotas Vainius Vaisvilkas Valimantas Zygimantas
-			Vidmantas Vingoldas Virmantas Visvaldis Vizgirdas Vykintas Vytautas Vytenis Zivinbudas 
-		}
-
-		last_names = {
-			Ugandi Gediminai Radziwill Gostautas Astikas Kesgaila Chodkiewicz Olshanski Chartoryski Giedraiciai Pac Plater Tyzenhaus Sapieha Ostrogski Oginski
-		}
-	}
 	nowyswiat = {
 		color = {182 134 154}
 
@@ -2867,16 +2829,6 @@ polish_culture_group = {
 		last_names = {
 		Ugandi Gediminai Radziwill Gostautas Astikas Kesgaila Chodkiewicz Olshanski Chartoryski Giedraiciai Pac Plater Tyzenhaus Sapieha Ostrogski Oginski }
 	}
-	
-	union = PLC
-	hpm_union = POL
-}
-
-czecho_slovak_culture_group = {
-	leader = european
-	unit = AustriaHungaryGC
-	hpm_unit = EuropeanGC
-
 	czech = {
 		color = {120 120 255}
 
@@ -2908,6 +2860,15 @@ czecho_slovak_culture_group = {
 		Masaryk Móry Moyses Rázus Rohácek Rudnay Selepcéni Sidor Škultéty-Gábriš Šmik 
 		Sokol Štefánik Suchon Šverma Tiso Trcka Tuka Turanec Viest Zoch }
 	}
+
+	union = WSF
+}
+
+czecho_slovak_culture_group = {
+	leader = european
+	unit = AustriaHungaryGC
+	hpm_unit = EuropeanGC
+
 	novysvet = {
 		color = {100 134 236}
 
@@ -2953,7 +2914,6 @@ czecho_slovak_culture_group = {
 		Šafránek Schack Schubert Škoda Skuherský Smetana Šnejdárek Suk Svoboda Syrový 
 		Tomášek Tyl Vitásek "von Mittrowitz-Nettolitzky" Voríšek Wankel Weber Zíbrt Zívr Zoubek }
 		}
-	union = CZH
 }
 
 east_slavic = {
@@ -3078,8 +3038,7 @@ baltic = {
 	leader = european
 	unit = RussianGC
 	hpm_unit = EuropeanGC
-	lithuanian = {
-		hpm = yes
+	lithuanian = { 
 		color = {17 162 48}
 
 		first_names = { Adolfas Aleksandras Algirdas Andrius Antanas Arturas Arunas Augustinas Balys Boris
@@ -3332,10 +3291,7 @@ baltic = {
 		Sikkar Sirk Tõnisson Uluots Vaga Veske Vilbaste Vilms "von Uexküll" Warma
 		}
 	}
-	
 	union = UBD
-	hpm_union = none
-
 }
 
 levantine = {

--- a/EU4toV2/Data_Files/configurables/unions.txt
+++ b/EU4toV2/Data_Files/configurables/unions.txt
@@ -57,23 +57,21 @@ link = { tag = YUG culture = macedonian }
 link = { tag = YUG culture = slovene }
 link = { tag = YUG culture = bosniak }
 
-#Polish-Lithuanian => PLC
-link = { tag = PLC culture = polish } #and Poland
-link = { tag = PLC culture = lithuanian } #and Lithuania
-link = { tag = PLC culture = western_slavic }
-link = { tag = PLC culture = sorbian }
-
-#Czechoslovakian => Czechoslovakia
-link = { tag = CZH culture = czech }
-link = { tag = CZH culture = slovak }
+#West-Slavic => Zapadoslavia
+link = { tag = WSF culture = polish } #and Poland
+link = { tag = WSF culture = western_slavic } #Wends
+link = { tag = WSF culture = sorbian }
+link = { tag = WSF culture = czech }
+link = { tag = WSF culture = slovak }
 
 #East Slavic
 link = { tag = RUS culture = russian } #Russia
 
 #Baltic => United Baltic
-link = { tag = UBD culture = latvian } #and Latvia
-link = { tag = UBD culture = estonian } #and Estonia
-
+link = { tag = UBD culture = latvian } # Latvia
+link = { tag = UBD culture = estonian } # Estonia
+link = { tag = UBD culture = lithuanian } # Lithuania
+link = { tag = UBD culture = pruthenian } # Pruthenia
 
 #Arab => Arabia
 #link = { tag = ARA culture = maghrebi }

--- a/EU4toV2/Data_Files/configurables/vn_colonial.txt
+++ b/EU4toV2/Data_Files/configurables/vn_colonial.txt
@@ -86,20 +86,21 @@ link = { name = "Spanish Indonesia" key = 487 provinces = { 1455 1456 1457 1458 
 # Russian Alaska to St. Petersburg
 link = { name = "Alaska" key = 994 provinces = { 1 2 3 4 5 2631 } }
 
-# Russian North to Kotlas
-link = { name = "Russian North" key = 990 provinces = { 1029 2700 985 2699 986 2688 2687 2689 } }
-
-# Russian Siberia to Perm
-link = { name = "Russian Siberia" key = 1026 provinces = { 2695 1058 2685 1062 2682 2684 2614 2690 2613 2659 2615 2657 2680 2693 2655 2654 1066 2646 1065 2651 2650 2649 2672 2668 2642 1072 2639 2618 2638 1073 2663 2616 2622 2637 2634 2633 1074 2641 1080 2696 2644 2645 2648 1069 } }
-
-# Russian Urals to Ufa 
-link = { name = "Russian Urals" key = 1042 provinces = { 1059 2658 1061 1064 2686 } }
-
-# Russian Tartary to Ufa 
-link = { name = "Russian Tartary" key = 1042 provinces = { 1183 1060 2611 1181 1184 1067 1068 2698 2674 2691 1077 2701 1076 2683 1063 1070 2692 2656 2694 1075 2670 1078 1079 2671 2676 2677 2675 } }
-
 # Russian Scandinavia to Petrozavodsk 
 link = { name = "Russian Scandinavia" key = 995 provinces = { 983 984 988 2588 982 2587 } }
+
+# Russian North to Kotlas - decolonize unless RUS
+link = { name = "Russian North" key = 990 decolonize = RUS provinces = { 1029 2700 985 2699 986 2688 2687 2689 } }
+
+# Russian Siberia to Perm - decolonize unless RUS
+link = { name = "Russian Siberia" key = 1026 decolonize = RUS provinces = { 2695 1058 2685 1062 2682 2684 2614 2690 2613 2659 2615 2657 2680 2693 2655 2654 1066 2646 1065 2651 2650 2649 2672 2668 2642 1072 2639 2618 2638 1073 2663 2616 2622 2637 2634 2633 1074 2641 1080 2696 2644 2645 2648 1069 } }
+
+# Russian Urals to Ufa - decolonize unless RUS
+link = { name = "Russian Urals" key = 1042 decolonize = RUS provinces = { 1059 2658 1061 1064 2686 } }
+
+# Russian Tartary to Ufa - decolonize unless RUS
+link = { name = "Russian Tartary" key = 1042 decolonize = RUS provinces = { 1183 1060 2611 1181 1184 1067 1068 2698 2674 2691 1077 2701 1076 2683 1063 1070 2692 2656 2694 1075 2670 1078 1079 2671 2676 2677 2675 } }
+
 
 ###### Sweden ######
 

--- a/EU4toV2/Data_Files/fronter-options.txt
+++ b/EU4toV2/Data_Files/fronter-options.txt
@@ -23,13 +23,13 @@ option = {
 			name = 2
 			displayName = EXPIRE2
 			tooltip = EXPIRE2TIP
-			default = true
+			default = false
 		}
 		radioOption = {
 			name = 3
 			displayName = EXPIRE3
 			tooltip = EXPIRE3TIP
-			default = false		
+			default = true
 		}
 	}
 }

--- a/EU4toV2/Source/Mappers/VNColonialMapper/VNColonialMapping.cpp
+++ b/EU4toV2/Source/Mappers/VNColonialMapper/VNColonialMapping.cpp
@@ -14,6 +14,9 @@ void mappers::VNColonialMapping::registerKeys()
 	registerKeyword("name", [this](std::istream& theStream) {
 		name = commonItems::getString(theStream);
 	});
+	registerKeyword("decolonize", [this](std::istream& theStream) {
+		decolonizeBlocker = commonItems::getString(theStream);
+	});
 	registerKeyword("key", [this](std::istream& theStream) {
 		keyProvince = commonItems::getInt(theStream);
 	});

--- a/EU4toV2/Source/Mappers/VNColonialMapper/VNColonialMapping.h
+++ b/EU4toV2/Source/Mappers/VNColonialMapper/VNColonialMapping.h
@@ -10,6 +10,7 @@ class VNColonialMapping: commonItems::parser
 	explicit VNColonialMapping(std::istream& theStream);
 
 	[[nodiscard]] const auto& getName() const { return name; }
+	[[nodiscard]] const auto& getDecolonizeBlocker() const { return decolonizeBlocker; }
 	[[nodiscard]] auto getKeyProvince() const { return keyProvince; }
 	[[nodiscard]] const auto& getProvinces() const { return provinces; }
 
@@ -17,6 +18,7 @@ class VNColonialMapping: commonItems::parser
 	void registerKeys();
 
 	std::string name;
+	std::string decolonizeBlocker;
 	int keyProvince = 0;
 	std::vector<int> provinces;
 };


### PR DESCRIPTION
- VN russian colonial land is wiped unless key provinces owned by russia
- delete CZH as union and redistribute slavs into WSF and lihuanians to UBD
- default fronter to drop all dead cores
- Make no distinction between dead and recently deceased nations for purposes of core removal.