### PR TITLE
Add Mongol Khanate tag (KHA)

### DIFF
--- a/EU4ToVic2/Data_Files/blankMod/output/common/countries.txt
+++ b/EU4ToVic2/Data_Files/blankMod/output/common/countries.txt
@@ -369,6 +369,7 @@ HND 		="countries/India.txt"
 # East Asia
 QIN		="countries/Qing.txt"
 AIN     =   "countries/Ainu.txt"
+KHA     =   "countries/MongolKhanate.txt"
 
 # Americas
 AZT 	= "countries/Aztec.txt"


### PR DESCRIPTION
Cores are added via nationals.txt, but we never added country definition